### PR TITLE
Removed IHostEnvironment from conventions and builders

### DIFF
--- a/src/Configuration/ConfigurationOptions.cs
+++ b/src/Configuration/ConfigurationOptions.cs
@@ -8,6 +8,33 @@ namespace Rocket.Surgery.Extensions.Configuration
     public class ConfigOptions
     {
         /// <summary>
+        /// Default Constructor
+        /// </summary>
+        public ConfigOptions()
+        {
+
+        }
+
+        /// <summary>
+        /// Default constructor with environment name
+        /// </summary>
+        public ConfigOptions(string environmentName)
+        {
+            EnvironmentName = environmentName;
+        }
+
+        /// <summary>
+        /// Set the expected environment name
+        /// </summary>
+        /// <param name="environmentName"></param>
+        /// <returns></returns>
+        public ConfigOptions UseEnvironment(string environmentName)
+        {
+            EnvironmentName = environmentName;
+            return this;
+        }
+
+        /// <summary>
         /// Add an application configuration
         /// </summary>
         public ConfigOptions AddApplicationConfiguration(ConfigOptionApplicationDelegate @delegate)
@@ -26,6 +53,8 @@ namespace Rocket.Surgery.Extensions.Configuration
             EnvironmentConfiguration.Add(@delegate);
             return this;
         }
+
+        public string? EnvironmentName { get; private set; }
 
         /// <summary>
         /// Additional settings providers to be inserted after the default application settings file (typically appsettings.json)

--- a/src/Configuration/Rocket.Surgery.Extensions.Configuration.csproj
+++ b/src/Configuration/Rocket.Surgery.Extensions.Configuration.csproj
@@ -10,7 +10,6 @@
         <InternalsVisibleTo Include="Rocket.Surgery.Conventions.TestHost" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
         <PackageReference Include="Microsoft.Extensions.Configuration" />
         <PackageReference Include="System.Diagnostics.DiagnosticSource" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" />

--- a/src/Conventions.Abstractions/ConventionContextExtensions.cs
+++ b/src/Conventions.Abstractions/ConventionContextExtensions.cs
@@ -16,14 +16,14 @@ namespace Rocket.Surgery.Conventions
         /// <typeparam name="T"></typeparam>
         /// <param name="context">The context</param>
         /// <returns>T.</returns>
-        public static T Get<T>([NotNull] this IConventionContext context)
+        public static T? Get<T>([NotNull] this IConventionContext context) where T : class
         {
             if (context == null)
             {
                 throw new ArgumentNullException(nameof(context));
             }
 
-            return (T)context[typeof(T)]!;
+            return (T?)context[typeof(T)];
         }
 
         /// <summary>
@@ -33,15 +33,14 @@ namespace Rocket.Surgery.Conventions
         /// <param name="context">The context</param>
         /// <param name="key">The key where the value is saved</param>
         /// <returns>T.</returns>
-        [NotNull]
-        public static T Get<T>([NotNull] this IConventionContext context, string key)
+        public static T? Get<T>([NotNull] this IConventionContext context, string key) where T : class
         {
             if (context == null)
             {
                 throw new ArgumentNullException(nameof(context));
             }
 
-            return (T)context[key]!;
+            return (T?)context[key];
         }
 
         /// <summary>
@@ -158,7 +157,7 @@ namespace Rocket.Surgery.Conventions
         /// Check if this is a test host (to allow conventions to behave differently during unit tests)
         /// </summary>
         /// <param name="context">The context</param>
-        internal static HostType GetHostType(this IConventionContext context)
+        public static HostType GetHostType(this IConventionContext context)
             => context.Properties.TryGetValue(typeof(HostType), out var hostType)
                 ? (HostType)hostType!
                 : HostType.Undefined;

--- a/src/Conventions.Abstractions/ConventionHostBuilderExtensions.cs
+++ b/src/Conventions.Abstractions/ConventionHostBuilderExtensions.cs
@@ -1,6 +1,6 @@
 using System;
+using System.Collections.Generic;
 using JetBrains.Annotations;
-using Microsoft.Extensions.Hosting;
 using Rocket.Surgery.Conventions.Configuration;
 using Rocket.Surgery.Conventions.DependencyInjection;
 using Rocket.Surgery.Conventions.Logging;
@@ -20,10 +20,7 @@ namespace Rocket.Surgery.Conventions
         /// <param name="container">The container.</param>
         /// <param name="delegate">The delegate.</param>
         /// <returns>IConventionHostBuilder.</returns>
-        public static IConventionHostBuilder ConfigureServices(
-            [NotNull] this IConventionHostBuilder container,
-            ServiceConventionDelegate @delegate
-        )
+        public static IConventionHostBuilder ConfigureServices([NotNull] this IConventionHostBuilder container, ServiceConventionDelegate @delegate)
         {
             if (container == null)
             {
@@ -40,10 +37,7 @@ namespace Rocket.Surgery.Conventions
         /// <param name="container">The container.</param>
         /// <param name="delegate">The delegate.</param>
         /// <returns>IConventionHostBuilder.</returns>
-        public static IConventionHostBuilder ConfigureLogging(
-            [NotNull] this IConventionHostBuilder container,
-            LoggingConventionDelegate @delegate
-        )
+        public static IConventionHostBuilder ConfigureLogging([NotNull] this IConventionHostBuilder container, LoggingConventionDelegate @delegate)
         {
             if (container == null)
             {
@@ -60,10 +54,7 @@ namespace Rocket.Surgery.Conventions
         /// <param name="container">The container.</param>
         /// <param name="delegate">The delegate.</param>
         /// <returns>IConventionHostBuilder.</returns>
-        public static IConventionHostBuilder ConfigureConfiguration(
-            [NotNull] this IConventionHostBuilder container,
-            ConfigConventionDelegate @delegate
-        )
+        public static IConventionHostBuilder ConfigureConfiguration(            [NotNull] this IConventionHostBuilder container, ConfigConventionDelegate @delegate)
         {
             if (container == null)
             {
@@ -77,18 +68,18 @@ namespace Rocket.Surgery.Conventions
         /// <summary>
         /// Gets the convention host builder or creates one of it's missing.
         /// </summary>
-        /// <param name="hostBuilder"></param>
+        /// <param name="properties"></param>
         /// <returns></returns>
-        public static IConventionHostBuilder GetConventions(this IHostBuilder hostBuilder)
+        internal static IConventionHostBuilder GetConventions(this IDictionary<object, object?> properties)
         {
-            if (hostBuilder.Properties.TryGetValue(typeof(IConventionHostBuilder), out var value)
+            if (properties.TryGetValue(typeof(IConventionHostBuilder), out var value)
              && value is IConventionHostBuilder conventionHostBuilder)
             {
                 return conventionHostBuilder;
             }
 
-            conventionHostBuilder = new UninitializedConventionHostBuilder(hostBuilder.Properties);
-            hostBuilder.Properties.Add(typeof(IConventionHostBuilder), conventionHostBuilder);
+            conventionHostBuilder = new UninitializedConventionHostBuilder(properties);
+            properties.Add(typeof(IConventionHostBuilder), conventionHostBuilder);
             return conventionHostBuilder;
         }
 
@@ -98,15 +89,14 @@ namespace Rocket.Surgery.Conventions
         /// <typeparam name="T"></typeparam>
         /// <param name="context">The context</param>
         /// <returns>T.</returns>
-        [NotNull]
-        public static T Get<T>([NotNull] this IConventionHostBuilder context)
+        public static T? Get<T>([NotNull] this IConventionHostBuilder context) where T : class
         {
             if (context == null)
             {
                 throw new ArgumentNullException(nameof(context));
             }
 
-            return (T)context.ServiceProperties[typeof(T)]!;
+            return (T?)context.ServiceProperties[typeof(T)];
         }
 
         /// <summary>
@@ -116,15 +106,14 @@ namespace Rocket.Surgery.Conventions
         /// <param name="context">The context</param>
         /// <param name="key">The key where the value is saved</param>
         /// <returns>T.</returns>
-        [NotNull]
-        public static T Get<T>([NotNull] this IConventionHostBuilder context, string key)
+        public static T? Get<T>([NotNull] this IConventionHostBuilder context, string key) where T : class
         {
             if (context == null)
             {
                 throw new ArgumentNullException(nameof(context));
             }
 
-            return (T)context.ServiceProperties[key]!;
+            return (T?)context.ServiceProperties[key];
         }
 
         /// <summary>
@@ -135,8 +124,7 @@ namespace Rocket.Surgery.Conventions
         /// <param name="factory">The factory method in the event the type is not found</param>
         /// <returns>T.</returns>
         [NotNull]
-        public static T GetOrAdd<T>([NotNull] this IConventionHostBuilder builder, [NotNull] Func<T> factory)
-            where T : class
+        public static T GetOrAdd<T>([NotNull] this IConventionHostBuilder builder, [NotNull] Func<T> factory) where T : class
         {
             if (builder == null)
             {
@@ -168,12 +156,7 @@ namespace Rocket.Surgery.Conventions
         /// <param name="factory">The factory method in the event the type is not found</param>
         /// <returns>T.</returns>
         [NotNull]
-        public static T GetOrAdd<T>(
-            [NotNull] this IConventionHostBuilder builder,
-            string key,
-            [NotNull] Func<T> factory
-        )
-            where T : class
+        public static T GetOrAdd<T>([NotNull] this IConventionHostBuilder builder, string key, [NotNull] Func<T> factory) where T : class
         {
             if (builder == null)
             {
@@ -235,15 +218,14 @@ namespace Rocket.Surgery.Conventions
         /// <typeparam name="T"></typeparam>
         /// <param name="serviceProviderDictionary">The properties</param>
         /// <returns>T.</returns>
-        [NotNull]
-        public static T Get<T>([NotNull] this IServiceProviderDictionary serviceProviderDictionary)
+        public static T? Get<T>([NotNull] this IServiceProviderDictionary serviceProviderDictionary) where T : class
         {
             if (serviceProviderDictionary == null)
             {
                 throw new ArgumentNullException(nameof(serviceProviderDictionary));
             }
 
-            return (T)serviceProviderDictionary[typeof(T)]!;
+            return (T?)serviceProviderDictionary[typeof(T)];
         }
 
         /// <summary>
@@ -253,15 +235,14 @@ namespace Rocket.Surgery.Conventions
         /// <param name="serviceProviderDictionary">The properties</param>
         /// <param name="key">The key where the value is saved</param>
         /// <returns>T.</returns>
-        [NotNull]
-        public static T Get<T>([NotNull] this IServiceProviderDictionary serviceProviderDictionary, string key)
+        public static T? Get<T>([NotNull] this IServiceProviderDictionary serviceProviderDictionary, string key) where T : class
         {
             if (serviceProviderDictionary == null)
             {
                 throw new ArgumentNullException(nameof(serviceProviderDictionary));
             }
 
-            return (T)serviceProviderDictionary[key]!;
+            return (T?)serviceProviderDictionary[key];
         }
 
         /// <summary>
@@ -272,11 +253,7 @@ namespace Rocket.Surgery.Conventions
         /// <param name="factory">The factory method in the event the type is not found</param>
         /// <returns>T.</returns>
         [NotNull]
-        public static T GetOrAdd<T>(
-            [NotNull] this IServiceProviderDictionary serviceProviderDictionary,
-            [NotNull] Func<T> factory
-        )
-            where T : class
+        public static T GetOrAdd<T>([NotNull] this IServiceProviderDictionary serviceProviderDictionary, [NotNull] Func<T> factory) where T : class
         {
             if (serviceProviderDictionary == null)
             {
@@ -306,12 +283,7 @@ namespace Rocket.Surgery.Conventions
         /// <param name="factory">The factory method in the event the type is not found</param>
         /// <returns>T.</returns>
         [NotNull]
-        public static T GetOrAdd<T>(
-            [NotNull] this IServiceProviderDictionary serviceProviderDictionary,
-            string key,
-            [NotNull] Func<T> factory
-        )
-            where T : class
+        public static T GetOrAdd<T>([NotNull] this IServiceProviderDictionary serviceProviderDictionary, string key, [NotNull] Func<T> factory) where T : class
         {
             if (serviceProviderDictionary == null)
             {
@@ -356,11 +328,7 @@ namespace Rocket.Surgery.Conventions
         /// <param name="serviceProviderDictionary">The properties</param>
         /// <param name="key">The key where the value is saved</param>
         /// <param name="value">The value to save</param>
-        public static IServiceProviderDictionary Set<T>(
-            [NotNull] this IServiceProviderDictionary serviceProviderDictionary,
-            string key,
-            T value
-        )
+        public static IServiceProviderDictionary Set<T>([NotNull] this IServiceProviderDictionary serviceProviderDictionary, string key, T value)
         {
             if (serviceProviderDictionary == null)
             {
@@ -403,7 +371,7 @@ namespace Rocket.Surgery.Conventions
         /// Check if this is a test host (to allow conventions to behave differently during unit tests)
         /// </summary>
         /// <param name="context">The context</param>
-        internal static HostType GetHostType(this IConventionHostBuilder context) => context.ServiceProperties.TryGetValue(typeof(HostType), out var hostType)
+        public static HostType GetHostType(this IConventionHostBuilder context) => context.ServiceProperties.TryGetValue(typeof(HostType), out var hostType)
             ? (HostType)hostType!
             : HostType.Undefined;
 
@@ -411,7 +379,7 @@ namespace Rocket.Surgery.Conventions
         /// Check if this is a test host (to allow conventions to behave differently during unit tests)
         /// </summary>
         /// <param name="serviceProviderDictionary">The properties</param>
-        internal static HostType GetHostType(this IServiceProviderDictionary serviceProviderDictionary)
+        public static HostType GetHostType(this IServiceProviderDictionary serviceProviderDictionary)
             => serviceProviderDictionary.TryGetValue(typeof(HostType), out var hostType)
                 ? (HostType)hostType!
                 : HostType.Undefined;

--- a/src/Conventions.Abstractions/DependencyInjection/IServiceConventionContext.cs
+++ b/src/Conventions.Abstractions/DependencyInjection/IServiceConventionContext.cs
@@ -2,7 +2,6 @@
 using JetBrains.Annotations;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Rocket.Surgery.Conventions.Reflection;
 
 namespace Rocket.Surgery.Conventions.DependencyInjection
@@ -43,12 +42,5 @@ namespace Rocket.Surgery.Conventions.DependencyInjection
         /// </summary>
         /// <value>The on build.</value>
         [NotNull] IObservable<IServiceProvider> OnBuild { get; }
-
-        /// <summary>
-        /// The environment that this convention is running
-        /// Based on IHostEnvironment / IHostingEnvironment
-        /// </summary>
-        /// <value>The environment.</value>
-        [NotNull] IHostEnvironment Environment { get; }
     }
 }

--- a/src/Conventions.Abstractions/Logging/ILoggingContributionContext.cs
+++ b/src/Conventions.Abstractions/Logging/ILoggingContributionContext.cs
@@ -1,6 +1,5 @@
 using JetBrains.Annotations;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Hosting;
 using Rocket.Surgery.Conventions.Reflection;
 
 namespace Rocket.Surgery.Conventions.Logging
@@ -31,12 +30,5 @@ namespace Rocket.Surgery.Conventions.Logging
         /// </summary>
         /// <value>The configuration.</value>
         [NotNull] IConfiguration Configuration { get; }
-
-        /// <summary>
-        /// The environment that this convention is running
-        /// Based on IHostEnvironment / IHostingEnvironment
-        /// </summary>
-        /// <value>The environment.</value>
-        [NotNull] IHostEnvironment Environment { get; }
     }
 }

--- a/src/Conventions.Abstractions/Rocket.Surgery.Conventions.Abstractions.csproj
+++ b/src/Conventions.Abstractions/Rocket.Surgery.Conventions.Abstractions.csproj
@@ -7,7 +7,6 @@
     <ItemGroup>
         <ProjectReference Include="../Conventions.Attributes/Rocket.Surgery.Conventions.Attributes.csproj" />
         <PackageReference Include="Microsoft.Extensions.Logging" />
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
         <PackageReference Include="System.Diagnostics.DiagnosticSource" />
         <InternalsVisibleTo Include="Rocket.Surgery.Conventions" />
         <InternalsVisibleTo Include="Rocket.Surgery.Hosting" />

--- a/src/Conventions.CommandLine/CommandLineHostBuilderExtensions.cs
+++ b/src/Conventions.CommandLine/CommandLineHostBuilderExtensions.cs
@@ -1,6 +1,5 @@
 using System;
 using JetBrains.Annotations;
-using Microsoft.Extensions.Hosting;
 using Rocket.Surgery.Conventions.CommandLine;
 
 // ReSharper disable once CheckNamespace
@@ -17,10 +16,7 @@ namespace Rocket.Surgery.Conventions
         /// <param name="container">The container.</param>
         /// <param name="delegate">The delegate.</param>
         /// <returns>IConventionHostBuilder.</returns>
-        public static IConventionHostBuilder ConfigureCommandLine(
-            [NotNull] this IConventionHostBuilder container,
-            CommandLineConventionDelegate @delegate
-        )
+        public static IConventionHostBuilder ConfigureCommandLine([NotNull] this IConventionHostBuilder container, CommandLineConventionDelegate @delegate)
         {
             if (container == null)
             {

--- a/src/Conventions.CommandLine/IApplicationState.cs
+++ b/src/Conventions.CommandLine/IApplicationState.cs
@@ -13,7 +13,7 @@ namespace Rocket.Surgery.Conventions.CommandLine
         /// Gets the remaining arguments.
         /// </summary>
         /// <value>The remaining arguments.</value>
-        string[] RemainingArguments { get; }
+        string[]? RemainingArguments { get; }
 
         /// <summary>
         /// Gets a value indicating whether this <see cref="IApplicationState" /> is verbose.

--- a/src/Conventions.TestHost/Internals/TestHostFactory.cs
+++ b/src/Conventions.TestHost/Internals/TestHostFactory.cs
@@ -38,7 +38,6 @@ namespace Rocket.Surgery.Conventions.Internals
                 testHostBuilder.AssemblyCandidateFinder,
                 serviceCollection,
                 hostBuilderContext.Configuration,
-                hostBuilderContext.HostingEnvironment,
                 testHostBuilder.DiagnosticLogger,
                 testHostBuilder.Properties
             );

--- a/src/Conventions.TestHost/TestHost.cs
+++ b/src/Conventions.TestHost/TestHost.cs
@@ -297,7 +297,7 @@ namespace Rocket.Surgery.Conventions
                     builder.UseAssemblies(_assemblies);
                 }
 
-                builder.Set(HostType.UnitTestHost);
+                builder.Properties[typeof(HostType)] = HostType.UnitTestHost;
                 builder.Set(_logger);
                 builder.Set(_loggerFactory);
 

--- a/src/Conventions.TestHost/TestHostBuilder.cs
+++ b/src/Conventions.TestHost/TestHostBuilder.cs
@@ -134,7 +134,7 @@ namespace Rocket.Surgery.Conventions
             return this;
         }
 
-        private IConventionHostBuilder ConventionHostBuilder => this.GetConventions();
+        private IConventionHostBuilder ConventionHostBuilder => Properties.GetConventions();
 
         [ExcludeFromCodeCoverage]
         public IConventionScanner Scanner => ConventionHostBuilder.Scanner;
@@ -199,7 +199,6 @@ namespace Rocket.Surgery.Conventions
         /// Get a value by type from the context
         /// </summary>
         /// <typeparam name="T">The type of the value</typeparam>
-        /// <param name="context">The context</param>
         /// <param name="value">The value to save</param>
         public TestHostBuilder Set<T>(T value)
         {
@@ -211,7 +210,6 @@ namespace Rocket.Surgery.Conventions
         /// Get a value by type from the context
         /// </summary>
         /// <typeparam name="T">The type of the value</typeparam>
-        /// <param name="context">The context</param>
         /// <param name="key">The key where the value is saved</param>
         /// <param name="value">The value to save</param>
         public TestHostBuilder Set<T>(string key, T value)

--- a/src/Conventions/Configuration/ConfigBuilder.cs
+++ b/src/Conventions/Configuration/ConfigBuilder.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace Rocket.Surgery.Conventions.Configuration
@@ -30,7 +29,6 @@ namespace Rocket.Surgery.Conventions.Configuration
         /// Initializes a new instance of the <see cref="ConfigBuilder" /> class.
         /// </summary>
         /// <param name="scanner">The scanner.</param>
-        /// <param name="environment">The environment.</param>
         /// <param name="configuration">The configuration.</param>
         /// <param name="diagnosticSource">The diagnostic source.</param>
         /// <param name="properties">The properties.</param>
@@ -45,22 +43,14 @@ namespace Rocket.Surgery.Conventions.Configuration
         /// </exception>
         public ConfigBuilder(
             IConventionScanner scanner,
-            IHostEnvironment environment,
             IConfiguration configuration,
             ILogger diagnosticSource,
             IDictionary<object, object?> properties
         ) : base(scanner, properties)
         {
-            Environment = environment;
             Configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             Logger = diagnosticSource ?? throw new ArgumentNullException(nameof(diagnosticSource));
         }
-
-        /// <summary>
-        /// Gets the environment.
-        /// </summary>
-        /// <value>The environment.</value>
-        public IHostEnvironment Environment { get; }
 
         /// <summary>
         /// Gets the configuration.

--- a/src/Conventions/Logging/LoggingBuilder.cs
+++ b/src/Conventions/Logging/LoggingBuilder.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Rocket.Surgery.Conventions.Reflection;
 
@@ -32,7 +31,6 @@ namespace Rocket.Surgery.Conventions.Logging
         /// <param name="assemblyProvider">The assembly provider.</param>
         /// <param name="assemblyCandidateFinder">The assembly candidate finder.</param>
         /// <param name="services">The services.</param>
-        /// <param name="environment">The environment.</param>
         /// <param name="configuration">The configuration.</param>
         /// <param name="diagnosticSource">The diagnostic source.</param>
         /// <param name="properties">The properties.</param>
@@ -50,13 +48,11 @@ namespace Rocket.Surgery.Conventions.Logging
             IAssemblyProvider assemblyProvider,
             IAssemblyCandidateFinder assemblyCandidateFinder,
             IServiceCollection services,
-            IHostEnvironment environment,
             IConfiguration configuration,
             ILogger diagnosticSource,
             IDictionary<object, object?> properties
         ) : base(scanner, assemblyProvider, assemblyCandidateFinder, properties)
         {
-            Environment = environment ?? throw new ArgumentNullException(nameof(environment));
             Services = services ?? throw new ArgumentNullException(nameof(services));
             Configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             Logger = diagnosticSource ?? throw new ArgumentNullException(nameof(diagnosticSource));
@@ -90,12 +86,5 @@ namespace Rocket.Surgery.Conventions.Logging
         /// </summary>
         /// <value>The logger.</value>
         public ILogger Logger { get; }
-
-        /// <summary>
-        /// The environment that this convention is running
-        /// Based on IHostEnvironment / IHostingEnvironment
-        /// </summary>
-        /// <value>The environment.</value>
-        public IHostEnvironment Environment { get; }
     }
 }

--- a/src/Conventions/Logging/LoggingServiceConvention.cs
+++ b/src/Conventions/Logging/LoggingServiceConvention.cs
@@ -58,11 +58,10 @@ namespace Rocket.Surgery.Conventions.Logging
             }
 
             var loggingBuilder = new LoggingBuilder(
-                context.Get<IConventionScanner>(),
+                context.Get<IConventionScanner>()!,
                 context.AssemblyProvider,
                 context.AssemblyCandidateFinder,
                 context.Services,
-                context.Environment,
                 context.Configuration,
                 context.Logger,
                 context.Properties

--- a/src/Conventions/UseLoggingHostBuilderExtensions.cs
+++ b/src/Conventions/UseLoggingHostBuilderExtensions.cs
@@ -1,6 +1,5 @@
 using System;
 using JetBrains.Annotations;
-using Microsoft.Extensions.Hosting;
 using Rocket.Surgery.Conventions.Logging;
 
 // ReSharper disable once CheckNamespace

--- a/src/Hosting/RocketHostExtensions.cs
+++ b/src/Hosting/RocketHostExtensions.cs
@@ -495,7 +495,7 @@ namespace Rocket.Surgery.Hosting
         /// <returns>RocketHostBuilder.</returns>
         internal static RocketHostBuilder GetOrCreateBuilder(IHostBuilder builder, Type? scannerType = null)
         {
-            var conventionHostBuilder = builder.GetConventions();
+            var conventionHostBuilder = builder.Properties.GetConventions();
             if (conventionHostBuilder is RocketHostBuilder rocketHostBuilder)
             {
                 return rocketHostBuilder;
@@ -509,8 +509,8 @@ namespace Rocket.Surgery.Hosting
                 var serviceProviderDictionary = uninitializedHostBuilder.ServiceProperties;
                 serviceProviderDictionary
                    .Set<ILogger>(logger)
-                   .Set(HostType.Live)
-                   .Set(builder);
+                   .Set(builder)
+                   .Set(HostType.Live);
                 var assemblyCandidateFinder = new DependencyContextAssemblyCandidateFinder(dependencyContext, logger);
                 var assemblyProvider = new DependencyContextAssemblyProvider(dependencyContext, logger);
                 var scanner = ConvertTo(
@@ -527,7 +527,7 @@ namespace Rocket.Surgery.Hosting
                    .ConfigureHostConfiguration(host.CaptureArguments)
                    .ConfigureHostConfiguration(host.ConfigureCli)
                    .ConfigureAppConfiguration(host.ReplaceArguments)
-                   .UseLocalConfiguration(() => serviceProviderDictionary.GetOrAdd(() => new ConfigOptions()))
+                   .ConfigureAppConfiguration((context, configurationBuilder) => configurationBuilder.UseLocalConfiguration(serviceProviderDictionary.GetOrAdd(() => new ConfigOptions()).UseEnvironment(context.HostingEnvironment.EnvironmentName)))
                    .ConfigureAppConfiguration(host.ConfigureAppConfiguration)
                    .ConfigureServices(host.ConfigureServices)
                    .UseServiceProviderFactory(host.DefaultServices);

--- a/test/Conventions.Tests/DependencyInjection/ServiceBuilderTests.cs
+++ b/test/Conventions.Tests/DependencyInjection/ServiceBuilderTests.cs
@@ -5,6 +5,7 @@ using DryIoc;
 using FakeItEasy;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Rocket.Surgery.Conventions;
 using Rocket.Surgery.Conventions.DependencyInjection;
 using Rocket.Surgery.Conventions.Reflection;
@@ -27,13 +28,14 @@ namespace Rocket.Surgery.Conventions.Tests.DependencyInjection
         {
             var assemblyProvider = AutoFake.Provide<IAssemblyProvider>(new TestAssemblyProvider());
             var services = AutoFake.Provide<IServiceCollection>(new ServiceCollection());
+            AutoFake.Provide<IDictionary<object, object?>>(new Dictionary<object, object?>() { [typeof(IHostEnvironment)] = AutoFake.Resolve<IHostEnvironment>() });
             var servicesBuilder = AutoFake.Resolve<ServicesBuilder>();
 
             servicesBuilder.AssemblyProvider.Should().BeSameAs(assemblyProvider);
             servicesBuilder.AssemblyCandidateFinder.Should().NotBeNull();
             servicesBuilder.Services.Should().BeSameAs(services);
             servicesBuilder.Configuration.Should().NotBeNull();
-            servicesBuilder.Environment.Should().NotBeNull();
+            servicesBuilder.Properties.Should().ContainKey(typeof(IHostEnvironment));
 
             Action a = () => { servicesBuilder.PrependConvention(A.Fake<IServiceConvention>()); };
             a.Should().NotThrow();

--- a/test/Conventions.Tests/Logging/LoggingBuilderTests.cs
+++ b/test/Conventions.Tests/Logging/LoggingBuilderTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using FakeItEasy;
 using FluentAssertions;
+using Microsoft.Extensions.Hosting;
 using Rocket.Surgery.Conventions.Logging;
 using Rocket.Surgery.Conventions.Reflection;
 using Rocket.Surgery.Extensions.Testing;
@@ -15,13 +17,14 @@ namespace Rocket.Surgery.Conventions.Tests.Logging
         public void Constructs()
         {
             var assemblyProvider = AutoFake.Provide<IAssemblyProvider>(new TestAssemblyProvider());
+            AutoFake.Provide<IDictionary<object, object?>>(new Dictionary<object, object?>() { [typeof(IHostEnvironment)] = AutoFake.Resolve<IHostEnvironment>() });
             var builder = AutoFake.Resolve<LoggingBuilder>();
 
             builder.AssemblyProvider.Should().BeSameAs(assemblyProvider);
             builder.AssemblyCandidateFinder.Should().NotBeNull();
             builder.Services.Should().NotBeNull();
             builder.Configuration.Should().NotBeNull();
-            builder.Environment.Should().NotBeNull();
+            builder.Properties.Should().ContainKey(typeof(IHostEnvironment));
             Action a = () => { builder.PrependConvention(A.Fake<ILoggingConvention>()); };
             a.Should().NotThrow();
             a = () => { builder.PrependDelegate(delegate { }); };


### PR DESCRIPTION
It will be available inside of the properties dictionary, when in context