### PR TITLE
Added support for setup conventions.  These conventions can be used t…

### DIFF
--- a/docs/concepts/introduction.md
+++ b/docs/concepts/introduction.md
@@ -42,15 +42,17 @@ Conventions are then interfaces that are implemented by the class some examples 
 * <xref:Rocket.Surgery.Conventions.Configuration.IConfigurationConvention>
 * <xref:Rocket.Surgery.Conventions.DependencyInjection.IServiceConvention>
 * <xref:Rocket.Surgery.Conventions.Logging.ILoggingConvention>
+* <xref:Rocket.Surgery.Conventions.Setup.ISetupConvention>
 * <xref:Rocket.Surgery.Hosting.IHostingConvention>
 
-ad-hoc Conventions (or delegate Conventions) are a different kind of convention but written as a delegate, but they generally mirror the method given by the Convention interface.  
+ad-hoc Conventions (or delegate Conventions) are a different kind of convention but written as a delegate, but they mirror the method given by the Convention interface.  
 These can be used to during program startup just like `ConfigureServices` are used today. 
 
 Some examples are:
 * <xref:Rocket.Surgery.Conventions.Configuration.ConfigurationConvention>
 * <xref:Rocket.Surgery.Conventions.DependencyInjection.ServiceConvention>
 * <xref:Rocket.Surgery.Conventions.Logging.LoggingConvention>
+* <xref:Rocket.Surgery.Conventions.Setup.SetupConvention>
 * <xref:Rocket.Surgery.Hosting.HostingConvention>
 
 ## Exporting a Convention

--- a/src/Conventions.Abstractions/ConventionHostBuilderExtensions.cs
+++ b/src/Conventions.Abstractions/ConventionHostBuilderExtensions.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using Rocket.Surgery.Conventions.Configuration;
 using Rocket.Surgery.Conventions.DependencyInjection;
 using Rocket.Surgery.Conventions.Logging;
+using Rocket.Surgery.Conventions.Setup;
 
 #pragma warning disable CS8601 // Possible null reference assignment.
 
@@ -17,6 +18,23 @@ namespace Rocket.Surgery.Conventions
     /// </summary>
     public static class ConventionHostBuilderExtensions
     {
+        /// <summary>
+        /// Setup a convention to run as soon as the context is created
+        /// </summary>
+        /// <param name="container">The container.</param>
+        /// <param name="delegate">The delegate.</param>
+        /// <returns><see cref="ConventionContextBuilder"/>.</returns>
+        public static ConventionContextBuilder SetupConvention([NotNull] this ConventionContextBuilder container, SetupConvention @delegate)
+        {
+            if (container == null)
+            {
+                throw new ArgumentNullException(nameof(container));
+            }
+
+            container.AppendDelegate(@delegate);
+            return container;
+        }
+
         /// <summary>
         /// Configure the services delegate to the convention scanner
         /// </summary>

--- a/src/Conventions.Abstractions/Rocket.Surgery.Conventions.Abstractions.csproj
+++ b/src/Conventions.Abstractions/Rocket.Surgery.Conventions.Abstractions.csproj
@@ -22,7 +22,4 @@
         <InternalsVisibleTo Include="Rocket.Surgery.Hosting.Tests" />
         <InternalsVisibleTo Include="Rocket.Surgery.WebAssembly.Hosting.Tests" />
     </ItemGroup>
-    <ItemGroup>
-        <Folder Include="Scanners" />
-    </ItemGroup>
 </Project>

--- a/src/Conventions.Abstractions/Setup/ISetupConvention.cs
+++ b/src/Conventions.Abstractions/Setup/ISetupConvention.cs
@@ -1,0 +1,16 @@
+﻿using JetBrains.Annotations;
+
+namespace Rocket.Surgery.Conventions.Setup
+{
+    /// <summary>
+    /// IInitConvention
+    /// </summary>
+    public interface ISetupConvention : IConvention
+    {
+        /// <summary>
+        /// Initialize or configure a convention before any other convention has run against the context.
+        /// </summary>
+        /// <param name="context"></param>
+        void Register([NotNull] IConventionContext context);
+    }
+}

--- a/src/Conventions.Abstractions/Setup/SetupConvention.cs
+++ b/src/Conventions.Abstractions/Setup/SetupConvention.cs
@@ -1,0 +1,13 @@
+﻿using JetBrains.Annotations;
+
+namespace Rocket.Surgery.Conventions.Setup
+{
+    /// <summary>
+    /// Initialize or configure a convention before any other convention has run against the context.
+    /// </summary>
+    /// <remarks>
+    /// This runs immediately after creating a convention context
+    /// </remarks>
+    /// <param name="context">The context.</param>
+    public delegate void SetupConvention([NotNull] IConventionContext context);
+}

--- a/src/Conventions/ConventionContext.cs
+++ b/src/Conventions/ConventionContext.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Rocket.Surgery.Conventions.Extensions;
 using Rocket.Surgery.Conventions.Reflection;
 
 namespace Rocket.Surgery.Conventions
@@ -27,7 +28,9 @@ namespace Rocket.Surgery.Conventions
             var assemblyProvider = builder._assemblyProviderFactory(builder._source, builder.Get<ILogger>());
             var assemblyCandidateFinder = builder._assemblyCandidateFinderFactory(builder._source, builder.Get<ILogger>());
             var provider = ConventionContextHelpers.CreateProvider(builder, assemblyCandidateFinder, builder.Get<ILogger>());
-            return new ConventionContext(provider, assemblyProvider, assemblyCandidateFinder, builder.Properties.ToDictionary(z => z.Key, z => z.Value));
+            var context = new ConventionContext(provider, assemblyProvider, assemblyCandidateFinder, builder.Properties.ToDictionary(z => z.Key, z => z.Value));
+            context.ApplyConventions();
+            return context;
         }
 
         /// <summary>

--- a/src/Conventions/Extensions/RocketSurgerySetupExtensions.cs
+++ b/src/Conventions/Extensions/RocketSurgerySetupExtensions.cs
@@ -1,0 +1,32 @@
+﻿using Rocket.Surgery.Conventions.Setup;
+
+namespace Rocket.Surgery.Conventions.Extensions
+{
+    /// <summary>
+    /// Extension method to apply configuration conventions
+    /// </summary>
+    internal static class RocketSurgerySetupExtensions
+    {
+        /// <summary>
+        /// Apply configuration conventions
+        /// </summary>
+        /// <param name="conventionContext"></param>
+        /// <returns></returns>
+        public static IConventionContext ApplyConventions(this IConventionContext conventionContext)
+        {
+            foreach (var item in conventionContext.Conventions.Get<ISetupConvention, SetupConvention>())
+            {
+                if (item is ISetupConvention convention)
+                {
+                    convention.Register(conventionContext);
+                }
+                else if (item is SetupConvention @delegate)
+                {
+                    @delegate(conventionContext);
+                }
+            }
+
+            return conventionContext;
+        }
+    }
+}

--- a/src/Conventions/Rocket.Surgery.Conventions.csproj
+++ b/src/Conventions/Rocket.Surgery.Conventions.csproj
@@ -19,7 +19,4 @@
         <InternalsVisibleTo Include="Rocket.Surgery.WebAssembly.Hosting" />
         <InternalsVisibleTo Include="Rocket.Surgery.WebAssembly.Hosting.Abstractions" />
     </ItemGroup>
-    <ItemGroup>
-        <Folder Include="Conventions" />
-    </ItemGroup>
 </Project>

--- a/test/Conventions.Tests/ConventionContextTests.cs
+++ b/test/Conventions.Tests/ConventionContextTests.cs
@@ -12,7 +12,9 @@ using Rocket.Surgery.Conventions;
 using Rocket.Surgery.Conventions.Configuration;
 using Rocket.Surgery.Conventions.DependencyInjection;
 using Rocket.Surgery.Conventions.Reflection;
+using Rocket.Surgery.Conventions.Setup;
 using Rocket.Surgery.Extensions.Testing;
+using System.Reflection;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -96,6 +98,30 @@ namespace Rocket.Surgery.Conventions.Tests
             contextBuilder.PrependConvention(convention);
 
             ConventionContextHelpers.CreateProvider(contextBuilder, new TestAssemblyProvider(), Logger).GetAll().Should().Contain(convention);
+        }
+
+        [Fact]
+        public void Setups()
+        {
+            var contextBuilder = new ConventionContextBuilder(new Dictionary<object, object?>())
+               .UseAssemblies(Array.Empty<Assembly>());
+            var convention = A.Fake<ISetupConvention>();
+            contextBuilder.PrependConvention(convention);
+
+            var context = ConventionContext.From(contextBuilder);
+            A.CallTo(() => convention.Register(context)).MustHaveHappenedOnceExactly();
+        }
+
+        [Fact]
+        public void Setups_With_Delegate()
+        {
+            var contextBuilder = new ConventionContextBuilder(new Dictionary<object, object?>())
+               .UseAssemblies(Array.Empty<Assembly>());
+            var convention = A.Fake<SetupConvention>();
+            contextBuilder.SetupConvention(convention);
+
+            var context = ConventionContext.From(contextBuilder);
+            A.CallTo(() => convention(context)).MustHaveHappenedOnceExactly();
         }
 
         [Fact]


### PR DESCRIPTION
…o configure the final context itself with defaults.  It is run immediately after the context is created.