### PR TITLE
Added support to customize namespaces of both imports and exports

### DIFF
--- a/.build/Build.CI.cs
+++ b/.build/Build.CI.cs
@@ -31,6 +31,7 @@ internal class LocalConstants
     "ci-ignore",
     GitHubActionsImage.WindowsLatest,
     GitHubActionsImage.UbuntuLatest,
+    AutoGenerate = false,
     On = new[] { GitHubActionsTrigger.Push },
     OnPushTags = new[] { "v*" },
     OnPushBranches = new[] { "master", "main", "next" },
@@ -42,6 +43,7 @@ internal class LocalConstants
     GitHubActionsImage.MacOsLatest,
     GitHubActionsImage.WindowsLatest,
     GitHubActionsImage.UbuntuLatest,
+    AutoGenerate = false,
     On = new[] { GitHubActionsTrigger.Push },
     OnPushTags = new[] { "v*" },
     OnPushBranches = new[] { "master", "main", "next" },
@@ -167,15 +169,6 @@ public partial class Solution
             {
                 Name = "nuget",
                 Path = "artifacts/nuget/",
-                If = "always()"
-            }
-        );
-
-        buildJob.Steps.Add(
-            new UploadArtifactStep("Publish Docs")
-            {
-                Name = "docs",
-                Path = "artifacts/docs/",
                 If = "always()"
             }
         );

--- a/.build/Build.CI.cs
+++ b/.build/Build.CI.cs
@@ -173,6 +173,15 @@ public partial class Solution
             }
         );
 
+        buildJob.Steps.Add(
+            new UploadArtifactStep("Publish Docs")
+            {
+                Name = "docs",
+                Path = "artifacts/docs/",
+                If = "always()"
+            }
+        );
+
         return configuration;
     }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,12 +134,6 @@ jobs:
         with:
           name: 'nuget'
           path: 'artifacts/nuget/'
-      - name: 🏺 Publish Docs
-        if: always()
-        uses: actions/upload-artifact@v2.3.1
-        with:
-          name: 'docs'
-          path: 'artifacts/docs/'
   Publish:
     needs:
       - Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,12 @@ jobs:
         with:
           name: 'nuget'
           path: 'artifacts/nuget/'
+      - name: 🏺 Publish Docs
+        if: always()
+        uses: actions/upload-artifact@v2.3.1
+        with:
+          name: 'docs'
+          path: 'artifacts/docs/'
   Publish:
     needs:
       - Build

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,7 @@
 . "$(dirname "$0")/_/husky.sh"
 
 npx lint-staged -d -r
+dotnet nuke --generate-configuration GitHubActions_ci --host GitHubActions
+git add .github/workflows/ci.yml
+dotnet nuke --generate-configuration GitHubActions_ci-ignore --host GitHubActions
+git add .github/workflows/ci-ignore.yml

--- a/sample/Sample.DependencyOne/Class1.cs
+++ b/sample/Sample.DependencyOne/Class1.cs
@@ -1,6 +1,7 @@
 ﻿using Rocket.Surgery.Conventions;
 using Sample.DependencyOne;
 
+[assembly: ExportConventions(Namespace = "Dep1", ClassName = "Dep1Exports")]
 [assembly: Convention(typeof(Class1))]
 
 namespace Sample.DependencyOne;

--- a/sample/Sample.DependencyTwo/Class2.cs
+++ b/sample/Sample.DependencyTwo/Class2.cs
@@ -1,6 +1,7 @@
 ﻿using Rocket.Surgery.Conventions;
 using Sample.DependencyTwo;
 
+[assembly: ExportConventions(Namespace = "Dep2", ClassName = "Dep2Exports")]
 [assembly: Convention(typeof(Class2))]
 
 namespace Sample.DependencyTwo;

--- a/src/Conventions.Analyzers/ConventionAttributeData.cs
+++ b/src/Conventions.Analyzers/ConventionAttributeData.cs
@@ -3,12 +3,15 @@
 namespace Rocket.Surgery.Conventions;
 
 internal record ConventionAttributeData(
-    string Namespace, INamedTypeSymbol LiveConventionAttribute, INamedTypeSymbol ExportCandidates, INamedTypeSymbol UnitTestConventionAttribute,
+    INamedTypeSymbol LiveConventionAttribute, INamedTypeSymbol ExportCandidates, INamedTypeSymbol UnitTestConventionAttribute,
     INamedTypeSymbol AfterConventionAttribute, INamedTypeSymbol DependsOnConventionAttribute, INamedTypeSymbol BeforeConventionAttribute,
-    INamedTypeSymbol DependentOfConventionAttribute
+    INamedTypeSymbol DependentOfConventionAttribute,
+    ConventionConfigurationData Configuration
 )
 {
-    public static ConventionAttributeData Create(string @namespace, Compilation compilation)
+    public string Namespace => Configuration.Namespace;
+
+    public static ConventionAttributeData Create(ConventionConfigurationData data, Compilation compilation)
     {
         var liveConventionAttribute = compilation.GetTypeByMetadataName("Rocket.Surgery.Conventions.LiveConventionAttribute")!;
         var exportConventionAttribute = compilation.GetTypeByMetadataName("Rocket.Surgery.Conventions.ExportConventionAttribute")!;
@@ -18,14 +21,14 @@ internal record ConventionAttributeData(
         var beforeConventionAttribute = compilation.GetTypeByMetadataName("Rocket.Surgery.Conventions.BeforeConventionAttribute")!;
         var dependentOfConventionAttribute = compilation.GetTypeByMetadataName("Rocket.Surgery.Conventions.DependentOfConventionAttribute")!;
         return new(
-            @namespace,
             liveConventionAttribute!,
             exportConventionAttribute!,
             unitTestConventionAttribute!,
             afterConventionAttribute!,
             dependsOnConventionAttribute!,
             beforeConventionAttribute!,
-            dependentOfConventionAttribute!
+            dependentOfConventionAttribute!,
+            data
         );
     }
 }

--- a/src/Conventions.Analyzers/ConventionAttributesGenerator.cs
+++ b/src/Conventions.Analyzers/ConventionAttributesGenerator.cs
@@ -395,11 +395,11 @@ public class ConventionAttributesGenerator : IIncrementalGenerator
         static IReadOnlyCollection<string> getReferences(Compilation compilation, bool exports, ConventionConfigurationData configurationData)
         {
             return compilation.References
-                              .Select(x => compilation.GetAssemblyOrModuleSymbol(x))
+                              .Select(compilation.GetAssemblyOrModuleSymbol)
+                              .OfType<IAssemblySymbol>()
                               .Select(
-                                   s =>
+                                   symbol =>
                                    {
-                                       if (s is not IAssemblySymbol symbol) return "";
                                        try
                                        {
                                            var data = ConventionConfigurationData.FromAssemblyAttributes(symbol, "Exports");

--- a/src/Conventions.Analyzers/ConventionAttributesGenerator.cs
+++ b/src/Conventions.Analyzers/ConventionAttributesGenerator.cs
@@ -4,11 +4,115 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using static Rocket.Surgery.Conventions.Helpers;
 
 // ReSharper disable UnusedVariable
 namespace Rocket.Surgery.Conventions;
 // TODO: analyzers
 //
+
+internal record ConventionConfigurationData(string Namespace, string ClassName)
+{
+    private record InnerConventionConfigurationData(string? Namespace, string ClassName);
+
+    public static IncrementalValueProvider<ConventionConfigurationData> Create(
+        IncrementalGeneratorInitializationContext context, string attributeName, string className
+    )
+    {
+        return context.SyntaxProvider
+                      .CreateSyntaxProvider(
+                           (node, token) => node is AttributeListSyntax attributeListSyntax
+                                         && attributeListSyntax.Target?.Identifier.IsKind(SyntaxKind.AssemblyKeyword) == true
+                                         && findAttribute(attributeListSyntax, attributeName) is not null,
+                           (syntaxContext, token) =>
+                               syntaxContext.Node is AttributeListSyntax attributeListSyntax
+                                   ? findAttribute(attributeListSyntax, attributeName)
+                                   : default
+                       )
+                      .Where(z => z is not null)
+                      .Select(
+                           (attribute, _) =>
+                           {
+                               var data = new InnerConventionConfigurationData(null, className);
+                               if (attribute is null || attribute.ArgumentList is null or { Arguments.Count: 0 }) return data;
+                               foreach (var arg in attribute.ArgumentList.Arguments)
+                               {
+                                   if (arg is { NameEquals: null } or { Expression: null or not LiteralExpressionSyntax }) continue;
+                                   var syntax = (LiteralExpressionSyntax)arg.Expression;
+
+                                   data = arg.NameEquals.Name.Identifier.Text switch
+                                   {
+                                       nameof(InnerConventionConfigurationData.Namespace) => data with { Namespace = (string)syntax.Token.Value! },
+                                       nameof(InnerConventionConfigurationData.ClassName) => data with { ClassName = (string)syntax.Token.Value! },
+                                       _                                                  => data
+                                   };
+                               }
+
+                               return data;
+                           }
+                       )
+                      .Collect()
+                      .Select((z, t) => z.FirstOrDefault() ?? new InnerConventionConfigurationData(null, className))
+                      .Combine(context.CompilationProvider)
+                      .Select(
+                           (tuple, token) => new ConventionConfigurationData(
+                               tuple.Left.Namespace ?? GetNamespaceForCompilation(tuple.Right),
+                               tuple.Left.ClassName
+                           )
+                       );
+    }
+
+    public static ConventionConfigurationData FromAssemblyAttributes(IAssemblySymbol assemblySymbol, string type)
+    {
+        var data = new InnerConventionConfigurationData(null, type);
+        var prefix = $"Rocket.Surgery.ConventionConfigurationData.{type}";
+        foreach (var attribute in assemblySymbol.GetAttributes())
+        {
+            if (attribute is not { AttributeClass.MetadataName : "AssemblyMetadataAttribute", ConstructorArguments: { Length: 2 } }) continue;
+            var key = (string)attribute.ConstructorArguments[0].Value!;
+            if (!key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) continue;
+
+            var value = (string)attribute.ConstructorArguments[1].Value!;
+            data = key.Split('.').Last() switch
+            {
+                nameof(Namespace) => data with { Namespace = value },
+                nameof(ClassName) => data with { ClassName = value },
+                _                 => data
+            };
+        }
+
+        return new ConventionConfigurationData(data.Namespace ?? assemblySymbol.Identity.Name, data.ClassName);
+    }
+
+    public SyntaxList<AttributeListSyntax> ToAttributes(string type)
+    {
+        return List(
+            new[]
+            {
+                AddAssemblyAttribute($"Rocket.Surgery.ConventionConfigurationData.{type}.{nameof(Namespace)}", Namespace),
+                AddAssemblyAttribute($"Rocket.Surgery.ConventionConfigurationData.{type}.{nameof(ClassName)}", ClassName)
+            }
+        );
+    }
+
+    private static AttributeSyntax? findAttribute(AttributeListSyntax list, string name)
+    {
+        return list.Attributes.FirstOrDefault(
+            z => z.Name.ToFullString().TrimEnd().EndsWith(
+                     name, StringComparison.OrdinalIgnoreCase
+                 )
+              || z.Name.ToFullString().TrimEnd().EndsWith(
+                     $"{name}Attribute", StringComparison.OrdinalIgnoreCase
+                 )
+        );
+    }
+
+    private static string GetNamespaceForCompilation(Compilation compilation)
+    {
+        var @namespace = compilation.AssemblyName ?? "";
+        return ( @namespace.EndsWith(".Conventions", StringComparison.Ordinal) ? @namespace : @namespace + ".Conventions" ).TrimStart('.');
+    }
+}
 
 /// <summary>
 ///     Generator to handle materializing conventions as code instead of loading them at runtime
@@ -18,6 +122,7 @@ public class ConventionAttributesGenerator : IIncrementalGenerator
 {
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
+        var exportConfigurationCandidate = ConventionConfigurationData.Create(context, "ExportConventions", "Exports");
         var exportCandidates = context
                               .SyntaxProvider
                               .CreateSyntaxProvider(
@@ -25,7 +130,8 @@ public class ConventionAttributesGenerator : IIncrementalGenerator
                                    {
                                        return node is AttributeListSyntax { Target.Identifier.RawKind: (int)SyntaxKind.AssemblyKeyword } attributeListSyntax
                                            && attributeListSyntax.Attributes.Any(
-                                                  z => z.Name.ToFullString().TrimEnd().EndsWith("Convention", StringComparison.Ordinal)
+                                                  z => z.Name.ToFullString().TrimEnd().EndsWith("Convention", StringComparison.Ordinal) ||
+                                                       z.Name.ToFullString().TrimEnd().EndsWith("ConventionAttribute", StringComparison.Ordinal)
                                               );
                                    },
                                    static (syntaxContext, token) =>
@@ -80,41 +186,31 @@ public class ConventionAttributesGenerator : IIncrementalGenerator
 
         context.RegisterSourceOutput(
             context.CompilationProvider
-                   .Select((compilation, token) => ConventionAttributeData.Create(GetNamespaceForCompilation(compilation), compilation))
+                   .Combine(exportConfigurationCandidate)
+                   .Select((z, token) => ConventionAttributeData.Create(z.Right, z.Left))
                    .Combine(combinedExports.Collect())
                    .Combine(exportedConventions.Collect())
                    .Select((z, token) => ( data: z.Left.Left, conventions: z.Left.Right, exportedConventions: z.Right )),
             static (productionContext, tuple) => HandleConventionExports(productionContext, tuple.data, tuple.conventions, tuple.exportedConventions)
         );
 
+        var importConfigurationCandidate = ConventionConfigurationData.Create(context, "ImportConventions", "Imports");
+
         var importCandidates = context
                               .SyntaxProvider
                               .CreateSyntaxProvider(
                                    static (node, token) =>
                                    {
-                                       return (
-                                                  node is AttributeListSyntax attributeListSyntax
-                                               && attributeListSyntax.Target?.Identifier.IsKind(SyntaxKind.AssemblyKeyword) == true
-                                               && attributeListSyntax.Attributes.Any(
-                                                      z => z.Name.ToFullString().TrimEnd().EndsWith("ImportConventions", StringComparison.OrdinalIgnoreCase)
-                                                        || z.Name.ToFullString().TrimEnd().EndsWith(
-                                                               "ImportConventionsAttribute", StringComparison.OrdinalIgnoreCase
-                                                           )
-                                                  )
-                                              )
-                                            ||
-                                              (
-                                                  node is ClassDeclarationSyntax classDeclarationSyntax
-                                               && classDeclarationSyntax.AttributeLists.SelectMany(z => z.Attributes)
-                                                                        .Any(
-                                                                             z => z.Name.ToFullString().TrimEnd().EndsWith(
-                                                                                      "ImportConventions", StringComparison.OrdinalIgnoreCase
-                                                                                  )
-                                                                               || z.Name.ToFullString().TrimEnd().EndsWith(
-                                                                                      "ImportConventionsAttribute", StringComparison.OrdinalIgnoreCase
-                                                                                  )
-                                                                         )
-                                              );
+                                       return node is ClassDeclarationSyntax classDeclarationSyntax
+                                           && classDeclarationSyntax.AttributeLists.SelectMany(z => z.Attributes)
+                                                                    .Any(
+                                                                         z => z.Name.ToFullString().TrimEnd().EndsWith(
+                                                                                  "ImportConventions", StringComparison.OrdinalIgnoreCase
+                                                                              )
+                                                                           || z.Name.ToFullString().TrimEnd().EndsWith(
+                                                                                  "ImportConventionsAttribute", StringComparison.OrdinalIgnoreCase
+                                                                              )
+                                                                     );
                                    },
                                    static (syntaxContext, token) => syntaxContext.Node
                                );
@@ -122,28 +218,36 @@ public class ConventionAttributesGenerator : IIncrementalGenerator
             context.CompilationProvider
                    .Combine(importCandidates.Collect())
                    .Combine(combinedExports.Collect())
-                   .Select((z, token) => ( compilation: z.Left.Left, hasExports: z.Right.Any(), exportedCandidates: z.Left.Right )),
-            static (productionContext, tuple) => HandleConventionImports(productionContext, tuple.compilation, tuple.exportedCandidates, tuple.hasExports)
+                   .Combine(importConfigurationCandidate)
+                   .Combine(exportConfigurationCandidate)
+                   .Select(
+                        (z, token) => ( compilation: z.Left.Left.Left.Left, hasExports: z.Left.Left.Right.Any(), exportedCandidates: z.Left.Left.Left.Right,
+                                        importConfiguration: z.Left.Right, exportConfiguration: z.Right )
+                    ),
+            static (productionContext, tuple) => HandleConventionImports(
+                productionContext, tuple.compilation, tuple.exportedCandidates, tuple.hasExports, tuple.importConfiguration, tuple.exportConfiguration
+            )
         );
     }
 
-    private static string GetNamespaceForCompilation(Compilation compilation)
-    {
-        var @namespace = compilation.AssemblyName ?? "";
-        return ( @namespace.EndsWith(".Conventions", StringComparison.Ordinal) ? @namespace : @namespace + ".Conventions" ).TrimStart('.');
-    }
-
     private static void HandleConventionImports(
-        SourceProductionContext context, Compilation compilation, ImmutableArray<SyntaxNode> importCandidates, bool hasExports
+        SourceProductionContext context,
+        Compilation compilation,
+        ImmutableArray<SyntaxNode> importCandidates,
+        bool hasExports,
+        ConventionConfigurationData importConfiguration,
+        ConventionConfigurationData exportConfiguration
     )
     {
         IReadOnlyCollection<string>? references = null;
-        if (importCandidates.OfType<AttributeListSyntax>().Any())
-        {
-            references = getReferences(compilation, hasExports);
-            var block = references.Count == 0 ? Block(YieldStatement(SyntaxKind.YieldBreakStatement)) : addEnumerateExportStatements(references);
-            addAssemblySource(context, GetNamespaceForCompilation(compilation), block);
-        }
+        references = getReferences(compilation, hasExports, exportConfiguration);
+
+        var importsNamespace = importConfiguration.Namespace;
+
+        addAssemblySource(
+            context, references.Count == 0 ? Block(YieldStatement(SyntaxKind.YieldBreakStatement)) : addEnumerateExportStatements(references),
+            importConfiguration
+        );
 
         if (importCandidates.OfType<ClassDeclarationSyntax>().Any())
         {
@@ -155,11 +259,10 @@ public class ConventionAttributesGenerator : IIncrementalGenerator
                             UsingDirective(ParseName("System")),
                             UsingDirective(ParseName("System.Collections.Generic")),
                             UsingDirective(ParseName("Rocket.Surgery.Conventions")),
+                            UsingDirective(ParseName(importsNamespace)),
                         }
                     )
                 );
-            references ??= getReferences(compilation, hasExports);
-            var block = references.Count == 0 ? Block(YieldStatement(SyntaxKind.YieldBreakStatement)) : addEnumerateExportStatements(references);
             foreach (var declaration in importCandidates.OfType<ClassDeclarationSyntax>())
             {
                 var model = compilation.GetSemanticModel(declaration.SyntaxTree);
@@ -172,7 +275,40 @@ public class ConventionAttributesGenerator : IIncrementalGenerator
                                   .WithModifiers(declaration.Modifiers)
                                   .WithConstraintClauses(declaration.ConstraintClauses)
                                   .WithTypeParameterList(declaration.TypeParameterList)
-                                  .WithMembers(createConventionsMemberDeclaration(block))
+                                  .WithMembers(
+                                       SingletonList<MemberDeclarationSyntax>(
+                                           MethodDeclaration(
+                                                   GenericName(Identifier("IEnumerable")).WithTypeArgumentList(
+                                                       TypeArgumentList(SingletonSeparatedList<TypeSyntax>(IdentifierName("IConventionWithDependencies")))
+                                                   ),
+                                                   Identifier("GetConventions")
+                                               )
+                                              .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.StaticKeyword)))
+                                              .WithParameterList(
+                                                   ParameterList(
+                                                       SingletonSeparatedList(
+                                                           Parameter(Identifier("serviceProvider")).WithType(IdentifierName("IServiceProvider"))
+                                                       )
+                                                   )
+                                               )
+                                              .WithExpressionBody(
+                                                   ArrowExpressionClause(
+                                                       InvocationExpression(
+                                                               MemberAccessExpression(
+                                                                   SyntaxKind.SimpleMemberAccessExpression,
+                                                                   IdentifierName(importConfiguration.ClassName),
+                                                                   IdentifierName("GetConventions")
+                                                               )
+                                                           )
+                                                          .WithArgumentList(
+                                                               ArgumentList(SingletonSeparatedList(Argument(IdentifierName("serviceProvider"))))
+                                                           )
+                                                   )
+                                               )
+                                              .WithSemicolonToken(Token(SyntaxKind.SemicolonToken))
+                                              .WithLeadingTrivia(GetXmlSummary("The conventions imported into this assembly"))
+                                       )
+                                   )
                                   .NormalizeWhitespace()
                     ;
                 cu = cu.WithMembers(
@@ -189,9 +325,10 @@ public class ConventionAttributesGenerator : IIncrementalGenerator
             );
         }
 
-        static void addAssemblySource(SourceProductionContext context, string @namespace, BlockSyntax syntax)
+        static void addAssemblySource(SourceProductionContext context, BlockSyntax syntax, ConventionConfigurationData configurationData)
         {
             var cu = CompilationUnit()
+                    .WithAttributeLists(configurationData.ToAttributes("Imports"))
                     .WithUsings(
                          List(
                              new[]
@@ -204,15 +341,16 @@ public class ConventionAttributesGenerator : IIncrementalGenerator
                      )
                     .WithMembers(
                          SingletonList<MemberDeclarationSyntax>(
-                             NamespaceDeclaration(ParseName(@namespace))
+                             NamespaceDeclaration(ParseName(configurationData.Namespace))
                                 .WithMembers(
                                      SingletonList<MemberDeclarationSyntax>(
-                                         ClassDeclaration("Imports")
+                                         ClassDeclaration(configurationData.ClassName)
                                             .WithAttributeLists(
                                                  SingletonList(
                                                      AttributeList(
-                                                         SingletonSeparatedList(Attribute(ParseName("System.Runtime.CompilerServices.CompilerGenerated")))
-                                                     )
+                                                             SingletonSeparatedList(Attribute(ParseName("System.Runtime.CompilerServices.CompilerGenerated")))
+                                                         )
+                                                        .WithLeadingTrivia(GetXmlSummary("The class defined for importing conventions into this assembly"))
                                                  )
                                              )
                                             .WithModifiers(
@@ -220,7 +358,28 @@ public class ConventionAttributesGenerator : IIncrementalGenerator
                                                      Token(SyntaxKind.InternalKeyword), Token(SyntaxKind.StaticKeyword), Token(SyntaxKind.PartialKeyword)
                                                  )
                                              )
-                                            .WithMembers(createConventionsMemberDeclaration(syntax))
+                                            .WithMembers(
+                                                 SingletonList<MemberDeclarationSyntax>(
+                                                     MethodDeclaration(
+                                                             GenericName(Identifier("IEnumerable")).WithTypeArgumentList(
+                                                                 TypeArgumentList(
+                                                                     SingletonSeparatedList<TypeSyntax>(IdentifierName("IConventionWithDependencies"))
+                                                                 )
+                                                             ),
+                                                             Identifier("GetConventions")
+                                                         )
+                                                        .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.StaticKeyword)))
+                                                        .WithParameterList(
+                                                             ParameterList(
+                                                                 SingletonSeparatedList(
+                                                                     Parameter(Identifier("serviceProvider")).WithType(IdentifierName("IServiceProvider"))
+                                                                 )
+                                                             )
+                                                         )
+                                                        .WithBody(syntax)
+                                                        .WithLeadingTrivia(GetXmlSummary("The conventions imported into this assembly"))
+                                                 )
+                                             )
                                      )
                                  )
                          )
@@ -233,20 +392,32 @@ public class ConventionAttributesGenerator : IIncrementalGenerator
             );
         }
 
-        static IReadOnlyCollection<string> getReferences(Compilation compilation, bool exports)
+        static IReadOnlyCollection<string> getReferences(Compilation compilation, bool exports, ConventionConfigurationData configurationData)
         {
             return compilation.References
-                              .Select(compilation.GetAssemblyOrModuleSymbol)
-                              .OfType<IAssemblySymbol>()
-                               // __ for backwards compatibility
-                              .Where(z => z.TypeNames.Contains("__exports__") || z.TypeNames.Contains("Exports"))
+                              .Select(x => compilation.GetAssemblyOrModuleSymbol(x))
                               .Select(
-                                   symbol => (
-                                       symbol.GetTypeByMetadataName($"{symbol.Name}.Conventions.Exports")
-                                    ?? symbol.GetTypeByMetadataName($"{symbol.Name}.Exports")
-                                    ?? symbol.GetTypeByMetadataName($"{symbol.Name}.__conventions__.__exports__") )!.ToDisplayString()
+                                   s =>
+                                   {
+                                       if (s is not IAssemblySymbol symbol) return "";
+                                       try
+                                       {
+                                           var data = ConventionConfigurationData.FromAssemblyAttributes(symbol, "Exports");
+                                           return (
+                                               symbol.GetTypeByMetadataName($"{data.Namespace}.{data.ClassName}")
+                                            ?? symbol.GetTypeByMetadataName($"{data.Namespace}.Conventions.{data.ClassName}")
+                                            ?? symbol.GetTypeByMetadataName($"{symbol.Name}.Conventions.Exports")
+                                            ?? symbol.GetTypeByMetadataName($"{symbol.Name}.Exports")
+                                            ?? symbol.GetTypeByMetadataName($"{symbol.Name}.__conventions__.__exports__") )?.ToDisplayString() ?? "";
+                                       }
+                                       catch
+                                       {
+                                           return "";
+                                       }
+                                   }
                                )
-                              .Concat(exports ? new[] { GetNamespaceForCompilation(compilation) + ".Exports" } : Enumerable.Empty<string>())
+                              .Where(z => !string.IsNullOrWhiteSpace(z))
+                              .Concat(exports ? new[] { configurationData.Namespace + "." + configurationData.ClassName } : Enumerable.Empty<string>())
                               .ToArray();
         }
 
@@ -268,27 +439,6 @@ public class ConventionAttributesGenerator : IIncrementalGenerator
             }
 
             return block;
-        }
-
-        static SyntaxList<MemberDeclarationSyntax> createConventionsMemberDeclaration(BlockSyntax syntax)
-        {
-            return SingletonList<MemberDeclarationSyntax>(
-                MethodDeclaration(
-                        GenericName(Identifier("IEnumerable")).WithTypeArgumentList(
-                            TypeArgumentList(SingletonSeparatedList<TypeSyntax>(IdentifierName("IConventionWithDependencies")))
-                        ),
-                        Identifier("GetConventions")
-                    )
-                   .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.StaticKeyword)))
-                   .WithParameterList(
-                        ParameterList(
-                            SingletonSeparatedList(
-                                Parameter(Identifier("serviceProvider")).WithType(IdentifierName("IServiceProvider"))
-                            )
-                        )
-                    )
-                   .WithBody(syntax)
-            );
         }
     }
 
@@ -423,10 +573,11 @@ public class ConventionAttributesGenerator : IIncrementalGenerator
         var helperClass =
                 NamespaceDeclaration(ParseName(data.Namespace)).WithMembers(
                     SingletonList<MemberDeclarationSyntax>(
-                        ClassDeclaration("Exports")
+                        ClassDeclaration(data.Configuration.ClassName)
                            .WithAttributeLists(
                                 SingletonList(
                                     AttributeList(SingletonSeparatedList(Attribute(ParseName("System.Runtime.CompilerServices.CompilerGenerated"))))
+                                       .WithLeadingTrivia(GetXmlSummary("The class defined for exporting conventions from this assembly"))
                                 )
                             )
                            .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.StaticKeyword), Token(SyntaxKind.PartialKeyword)))
@@ -447,6 +598,7 @@ public class ConventionAttributesGenerator : IIncrementalGenerator
                                             )
                                         )
                                        .WithBody(helperClassBody)
+                                       .WithLeadingTrivia(GetXmlSummary("The conventions exports from this assembly"))
                                 )
                             )
                     )
@@ -465,23 +617,22 @@ public class ConventionAttributesGenerator : IIncrementalGenerator
                          }
                      )
                  )
-                .WithAttributeLists(
-                     SingletonList(
-                         AttributeList(
-                                 SingletonSeparatedList(
-                                     Attribute(IdentifierName("ExportedConventions"))
-                                        .WithArgumentList(
-                                             AttributeArgumentList(
-                                                 SeparatedList(
-                                                     conventions
-                                                        .Select(symbol => AttributeArgument(TypeOfExpression(ParseName(symbol.ToDisplayString()))))
-                                                 )
+                .WithAttributeLists(data.Configuration.ToAttributes("Exports"))
+                .AddAttributeLists(
+                     AttributeList(
+                             SingletonSeparatedList(
+                                 Attribute(IdentifierName("ExportedConventions"))
+                                    .WithArgumentList(
+                                         AttributeArgumentList(
+                                             SeparatedList(
+                                                 conventions
+                                                    .Select(symbol => AttributeArgument(TypeOfExpression(ParseName(symbol.ToDisplayString()))))
                                              )
                                          )
-                                 )
+                                     )
                              )
-                            .WithTarget(AttributeTargetSpecifier(Token(SyntaxKind.AssemblyKeyword)))
-                     )
+                         )
+                        .WithTarget(AttributeTargetSpecifier(Token(SyntaxKind.AssemblyKeyword)))
                  )
                 .WithMembers(SingletonList<MemberDeclarationSyntax>(helperClass));
 

--- a/src/Conventions.Attributes/ConventionsConfigurationAttribute.cs
+++ b/src/Conventions.Attributes/ConventionsConfigurationAttribute.cs
@@ -1,0 +1,20 @@
+﻿namespace Rocket.Surgery.Conventions;
+
+/// <summary>
+///     Base class to be used for both imports and exports for configuration
+/// </summary>
+public abstract class ConventionsConfigurationAttribute : Attribute
+{
+    /// <summary>
+    ///     The desired namespace for the emitted classes to go
+    /// </summary>
+    public string Namespace { get; set; } = null!;
+
+    /// <summary>
+    ///     The desired class name for the emitted class.
+    /// </summary>
+    /// <remarks>
+    ///     Default Imports or Exports
+    /// </remarks>
+    public string ClassName { get; set; } = null!;
+}

--- a/src/Conventions.Attributes/ExportConventionsAttribute.cs
+++ b/src/Conventions.Attributes/ExportConventionsAttribute.cs
@@ -1,0 +1,10 @@
+namespace Rocket.Surgery.Conventions;
+
+/// <summary>
+///     An attribute that lets you configure how exported conventions will behave
+/// </summary>
+/// <seealso cref="Attribute" />
+[AttributeUsage(AttributeTargets.Assembly)]
+public sealed class ExportConventionsAttribute : ConventionsConfigurationAttribute
+{
+}

--- a/src/Conventions.Attributes/ImportConventionsAttribute.cs
+++ b/src/Conventions.Attributes/ImportConventionsAttribute.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics;
-
 namespace Rocket.Surgery.Conventions;
 
 /// <summary>
@@ -7,7 +5,6 @@ namespace Rocket.Surgery.Conventions;
 /// </summary>
 /// <seealso cref="Attribute" />
 [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class, AllowMultiple = true)]
-[Conditional("CodeGeneration")]
-public sealed class ImportConventionsAttribute : Attribute
+public sealed class ImportConventionsAttribute : ConventionsConfigurationAttribute
 {
 }

--- a/src/Hosting/RocketContext.cs
+++ b/src/Hosting/RocketContext.cs
@@ -26,7 +26,7 @@ internal class RocketContext
         _hostBuilder = hostBuilder;
     }
 
-    public IConventionContext ConventionContext => (IConventionContext)_hostBuilder.Properties[typeof(IConventionContext)];
+    public IConventionContext Context => (IConventionContext)_hostBuilder.Properties[typeof(IConventionContext)];
 
     /// <summary>
     ///     Construct and compose hosting conventions
@@ -39,9 +39,9 @@ internal class RocketContext
             throw new KeyNotFoundException($"Could not find {nameof(ConventionContextBuilder)}");
 
         var conventionContextBuilder = (ConventionContextBuilder)conventionContextBuilderObject!;
-        var contextObject = Conventions.ConventionContext.From(conventionContextBuilder);
+        var contextObject = ConventionContext.From(conventionContextBuilder);
         _hostBuilder.Properties[typeof(IConventionContext)] = contextObject;
-        _hostBuilder.ApplyConventions(ConventionContext);
+        _hostBuilder.ApplyConventions(Context);
     }
 
     /// <summary>
@@ -64,9 +64,9 @@ internal class RocketContext
             throw new ArgumentNullException(nameof(configurationBuilder));
         }
 
-        ConventionContext.Properties.AddIfMissing(context.HostingEnvironment);
+        Context.Properties.AddIfMissing(context.HostingEnvironment);
         configurationBuilder.UseLocalConfiguration(
-            ConventionContext.GetOrAdd(() => new ConfigOptions()).UseEnvironment(context.HostingEnvironment.EnvironmentName)
+            Context.GetOrAdd(() => new ConfigOptions()).UseEnvironment(context.HostingEnvironment.EnvironmentName)
         );
 
         // Insert after all the normal configuration but before the environment specific configuration
@@ -94,7 +94,7 @@ internal class RocketContext
             ? configurationBuilder.Sources.Count - 1
             : configurationBuilder.Sources.IndexOf(source);
 
-        var cb = new ConfigurationBuilder().ApplyConventions(ConventionContext, configurationBuilder.Build());
+        var cb = new ConfigurationBuilder().ApplyConventions(Context, configurationBuilder.Build());
 
         configurationBuilder.Sources.Insert(
             index + 1,
@@ -123,14 +123,14 @@ internal class RocketContext
             throw new ArgumentNullException(nameof(services));
         }
 
-        ConventionContext.Properties.AddIfMissing(context.Configuration);
+        Context.Properties.AddIfMissing(context.Configuration);
 
-        services.ApplyConventions(ConventionContext);
-        new LoggingBuilder(services).ApplyConventions(ConventionContext);
+        services.ApplyConventions(Context);
+        new LoggingBuilder(services).ApplyConventions(Context);
     }
 
     public IServiceProviderFactory<object> UseServiceProviderFactory(HostBuilderContext context)
     {
-        return ConventionServiceProviderFactory.Wrap(ConventionContext, false);
+        return ConventionServiceProviderFactory.Wrap(Context, false);
     }
 }

--- a/test/Analyzers.Tests/ExportedConventionsTests.cs
+++ b/test/Analyzers.Tests/ExportedConventionsTests.cs
@@ -1,6 +1,3 @@
-using Sample.DependencyOne;
-using Sample.DependencyThree;
-using Sample.DependencyTwo;
 using Xunit;
 using static Rocket.Surgery.Conventions.Analyzers.Tests.GenerationHelpers;
 
@@ -28,12 +25,20 @@ using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
 using Rocket.Surgery.Conventions;
 
+[assembly: System.Reflection.AssemblyMetadata(""Rocket.Surgery.ConventionConfigurationData.Exports.Namespace"", ""TestProject.Conventions"")]
+[assembly: System.Reflection.AssemblyMetadata(""Rocket.Surgery.ConventionConfigurationData.Exports.ClassName"", ""Exports"")]
 [assembly: ExportedConventions(typeof(Rocket.Surgery.Conventions.Tests.Contrib))]
 namespace TestProject.Conventions
 {
+    /// <summary>
+    /// The class defined for exporting conventions from this assembly
+    /// </summary>
     [System.Runtime.CompilerServices.CompilerGenerated]
     public static partial class Exports
     {
+        /// <summary>
+        /// The conventions exports from this assembly
+        /// </summary>
         public static IEnumerable<IConventionWithDependencies> GetConventions(IServiceProvider serviceProvider)
         {
             yield return new ConventionWithDependencies(ActivatorUtilities.CreateInstance<Rocket.Surgery.Conventions.Tests.Contrib>(serviceProvider), HostType.Undefined);
@@ -43,9 +48,10 @@ namespace TestProject.Conventions
 ";
 
         await AssertGeneratedAsExpected<ConventionAttributesGenerator>(
-            new[] { typeof(Class1).Assembly, typeof(Class2).Assembly, typeof(Class3).Assembly },
+            await CreateDeps(),
             source,
-            expected
+            expected,
+            "Exported_Conventions.cs"
         ).ConfigureAwait(false);
     }
 
@@ -67,13 +73,21 @@ using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
 using Rocket.Surgery.Conventions;
 
+[assembly: System.Reflection.AssemblyMetadata(""Rocket.Surgery.ConventionConfigurationData.Exports.Namespace"", ""TestProject.Conventions"")]
+[assembly: System.Reflection.AssemblyMetadata(""Rocket.Surgery.ConventionConfigurationData.Exports.ClassName"", ""Exports"")]
 [assembly: ExportedConventions(typeof(Rocket.Surgery.Conventions.Tests.Contrib))]
 [assembly: Convention(typeof(Rocket.Surgery.Conventions.Tests.Contrib))]
 namespace TestProject.Conventions
 {
+    /// <summary>
+    /// The class defined for exporting conventions from this assembly
+    /// </summary>
     [System.Runtime.CompilerServices.CompilerGenerated]
     public static partial class Exports
     {
+        /// <summary>
+        /// The conventions exports from this assembly
+        /// </summary>
         public static IEnumerable<IConventionWithDependencies> GetConventions(IServiceProvider serviceProvider)
         {
             yield return new ConventionWithDependencies(ActivatorUtilities.CreateInstance<Rocket.Surgery.Conventions.Tests.Contrib>(serviceProvider), HostType.Undefined);
@@ -83,9 +97,10 @@ namespace TestProject.Conventions
 ";
 
         await AssertGeneratedAsExpected<ConventionAttributesGenerator>(
-            new[] { typeof(Class1).Assembly, typeof(Class2).Assembly, typeof(Class3).Assembly },
+            await CreateDeps(),
             source,
-            expected
+            expected,
+            "Exported_Conventions.cs"
         ).ConfigureAwait(false);
     }
 
@@ -112,12 +127,20 @@ using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
 using Rocket.Surgery.Conventions;
 
+[assembly: System.Reflection.AssemblyMetadata(""Rocket.Surgery.ConventionConfigurationData.Exports.Namespace"", ""TestProject.Conventions"")]
+[assembly: System.Reflection.AssemblyMetadata(""Rocket.Surgery.ConventionConfigurationData.Exports.ClassName"", ""Exports"")]
 [assembly: ExportedConventions(typeof(Rocket.Surgery.Conventions.Tests.Contrib))]
 namespace TestProject.Conventions
 {
+    /// <summary>
+    /// The class defined for exporting conventions from this assembly
+    /// </summary>
     [System.Runtime.CompilerServices.CompilerGenerated]
     public static partial class Exports
     {
+        /// <summary>
+        /// The conventions exports from this assembly
+        /// </summary>
         public static IEnumerable<IConventionWithDependencies> GetConventions(IServiceProvider serviceProvider)
         {
             yield return new ConventionWithDependencies(ActivatorUtilities.CreateInstance<Rocket.Surgery.Conventions.Tests.Contrib>(serviceProvider), HostType.{HostType});
@@ -128,9 +151,10 @@ namespace TestProject.Conventions
         ;
 
         await AssertGeneratedAsExpected<ConventionAttributesGenerator>(
-            new[] { typeof(Class1).Assembly, typeof(Class2).Assembly, typeof(Class3).Assembly },
+            await CreateDeps(),
             source,
-            expected
+            expected,
+            "Exported_Conventions.cs"
         ).ConfigureAwait(false);
     }
 
@@ -162,12 +186,20 @@ using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
 using Rocket.Surgery.Conventions;
 
+[assembly: System.Reflection.AssemblyMetadata(""Rocket.Surgery.ConventionConfigurationData.Exports.Namespace"", ""TestProject.Conventions"")]
+[assembly: System.Reflection.AssemblyMetadata(""Rocket.Surgery.ConventionConfigurationData.Exports.ClassName"", ""Exports"")]
 [assembly: ExportedConventions(typeof(Rocket.Surgery.Conventions.Tests.Contrib))]
 namespace TestProject.Conventions
 {
+    /// <summary>
+    /// The class defined for exporting conventions from this assembly
+    /// </summary>
     [System.Runtime.CompilerServices.CompilerGenerated]
     public static partial class Exports
     {
+        /// <summary>
+        /// The conventions exports from this assembly
+        /// </summary>
         public static IEnumerable<IConventionWithDependencies> GetConventions(IServiceProvider serviceProvider)
         {
             yield return new ConventionWithDependencies(ActivatorUtilities.CreateInstance<Rocket.Surgery.Conventions.Tests.Contrib>(serviceProvider), HostType.Live).WithDependency(DependencyDirection.{DependencyDirection}, typeof(Rocket.Surgery.Conventions.Tests.D));
@@ -180,7 +212,8 @@ namespace TestProject.Conventions
         await AssertGeneratedAsExpected<ConventionAttributesGenerator>(
             new[] { typeof(ExcludeFromCodeCoverageAttribute).Assembly },
             source,
-            expected
+            expected,
+            "Exported_Conventions.cs"
         ).ConfigureAwait(false);
     }
 
@@ -190,6 +223,7 @@ namespace TestProject.Conventions
         var source1 = @"
 using Rocket.Surgery.Conventions;
 
+[assembly: ExportConventions(Namespace = ""Source.Space"")]
 [assembly: Convention(typeof(Contrib1))]
 
 internal class Contrib1 : IConvention { }
@@ -210,19 +244,58 @@ using Rocket.Surgery.Conventions;
 
 internal class Contrib4 : IConvention { }
 ";
+        var expectedImports = @"using System;
+using System.Collections.Generic;
+using Rocket.Surgery.Conventions;
+
+[assembly: System.Reflection.AssemblyMetadata(""Rocket.Surgery.ConventionConfigurationData.Imports.Namespace"", ""TestProject.Conventions"")]
+[assembly: System.Reflection.AssemblyMetadata(""Rocket.Surgery.ConventionConfigurationData.Imports.ClassName"", ""Imports"")]
+namespace TestProject.Conventions
+{
+    /// <summary>
+    /// The class defined for importing conventions into this assembly
+    /// </summary>
+    [System.Runtime.CompilerServices.CompilerGenerated]
+    internal static partial class Imports
+    {
+        /// <summary>
+        /// The conventions imported into this assembly
+        /// </summary>
+        public static IEnumerable<IConventionWithDependencies> GetConventions(IServiceProvider serviceProvider)
+        {
+            foreach (var convention in Dep1.Dep1Exports.GetConventions(serviceProvider))
+                yield return convention;
+            foreach (var convention in Dep2.Dep2Exports.GetConventions(serviceProvider))
+                yield return convention;
+            foreach (var convention in SampleDependencyThree.Conventions.Exports.GetConventions(serviceProvider))
+                yield return convention;
+            foreach (var convention in Source.Space.Exports.GetConventions(serviceProvider))
+                yield return convention;
+        }
+    }
+}";
+
         var expected = @"
 using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
 using Rocket.Surgery.Conventions;
 
+[assembly: System.Reflection.AssemblyMetadata(""Rocket.Surgery.ConventionConfigurationData.Exports.Namespace"", ""Source.Space"")]
+[assembly: System.Reflection.AssemblyMetadata(""Rocket.Surgery.ConventionConfigurationData.Exports.ClassName"", ""Exports"")]
 [assembly: ExportedConventions(typeof(Contrib1), typeof(Contrib3), typeof(Contrib4), typeof(Contrib2))]
 [assembly: Convention(typeof(Contrib2))]
-namespace TestProject.Conventions
+namespace Source.Space
 {
+    /// <summary>
+    /// The class defined for exporting conventions from this assembly
+    /// </summary>
     [System.Runtime.CompilerServices.CompilerGenerated]
     public static partial class Exports
     {
+        /// <summary>
+        /// The conventions exports from this assembly
+        /// </summary>
         public static IEnumerable<IConventionWithDependencies> GetConventions(IServiceProvider serviceProvider)
         {
             yield return new ConventionWithDependencies(ActivatorUtilities.CreateInstance<Contrib1>(serviceProvider), HostType.Undefined);
@@ -234,9 +307,9 @@ namespace TestProject.Conventions
 }";
 
         await AssertGeneratedAsExpected<ConventionAttributesGenerator>(
-            new[] { typeof(Class1).Assembly, typeof(Class2).Assembly, typeof(Class3).Assembly },
+            await CreateDeps(),
             new[] { source1, source2, source3 },
-            new[] { expected }
+            new[] { expected, expectedImports }
         ).ConfigureAwait(false);
     }
 
@@ -261,12 +334,20 @@ using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
 using Rocket.Surgery.Conventions;
 
+[assembly: System.Reflection.AssemblyMetadata(""Rocket.Surgery.ConventionConfigurationData.Exports.Namespace"", ""TestProject.Conventions"")]
+[assembly: System.Reflection.AssemblyMetadata(""Rocket.Surgery.ConventionConfigurationData.Exports.ClassName"", ""Exports"")]
 [assembly: ExportedConventions(typeof(Rocket.Surgery.Conventions.Tests.Contrib))]
 namespace TestProject.Conventions
 {
+    /// <summary>
+    /// The class defined for exporting conventions from this assembly
+    /// </summary>
     [System.Runtime.CompilerServices.CompilerGenerated]
     public static partial class Exports
     {
+        /// <summary>
+        /// The conventions exports from this assembly
+        /// </summary>
         public static IEnumerable<IConventionWithDependencies> GetConventions(IServiceProvider serviceProvider)
         {
             yield return new ConventionWithDependencies(ActivatorUtilities.CreateInstance<Rocket.Surgery.Conventions.Tests.Contrib>(serviceProvider), HostType.Undefined);
@@ -276,9 +357,10 @@ namespace TestProject.Conventions
 ";
 
         await AssertGeneratedAsExpected<ConventionAttributesGenerator>(
-            new[] { typeof(Class1).Assembly, typeof(Class2).Assembly, typeof(Class3).Assembly },
+            await CreateDeps(),
             source,
-            expected
+            expected,
+            "Exported_Conventions.cs"
         ).ConfigureAwait(false);
     }
 
@@ -305,12 +387,20 @@ using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
 using Rocket.Surgery.Conventions;
 
+[assembly: System.Reflection.AssemblyMetadata(""Rocket.Surgery.ConventionConfigurationData.Exports.Namespace"", ""TestProject.Conventions"")]
+[assembly: System.Reflection.AssemblyMetadata(""Rocket.Surgery.ConventionConfigurationData.Exports.ClassName"", ""Exports"")]
 [assembly: ExportedConventions(typeof(Rocket.Surgery.Conventions.Tests.ParentContrib.Contrib))]
 namespace TestProject.Conventions
 {
+    /// <summary>
+    /// The class defined for exporting conventions from this assembly
+    /// </summary>
     [System.Runtime.CompilerServices.CompilerGenerated]
     public static partial class Exports
     {
+        /// <summary>
+        /// The conventions exports from this assembly
+        /// </summary>
         public static IEnumerable<IConventionWithDependencies> GetConventions(IServiceProvider serviceProvider)
         {
             yield return new ConventionWithDependencies(ActivatorUtilities.CreateInstance<Rocket.Surgery.Conventions.Tests.ParentContrib.Contrib>(serviceProvider), HostType.Undefined);
@@ -320,9 +410,10 @@ namespace TestProject.Conventions
 ";
 
         await AssertGeneratedAsExpected<ConventionAttributesGenerator>(
-            new[] { typeof(Class1).Assembly, typeof(Class2).Assembly, typeof(Class3).Assembly },
+            await CreateDeps(),
             source,
-            expected
+            expected,
+            "Exported_Conventions.cs"
         ).ConfigureAwait(false);
     }
 
@@ -349,12 +440,20 @@ using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
 using Rocket.Surgery.Conventions;
 
+[assembly: System.Reflection.AssemblyMetadata(""Rocket.Surgery.ConventionConfigurationData.Exports.Namespace"", ""TestProject.Conventions"")]
+[assembly: System.Reflection.AssemblyMetadata(""Rocket.Surgery.ConventionConfigurationData.Exports.ClassName"", ""Exports"")]
 [assembly: ExportedConventions(typeof(Rocket.Surgery.Conventions.Tests.ParentContrib.Contrib))]
 namespace TestProject.Conventions
 {
+    /// <summary>
+    /// The class defined for exporting conventions from this assembly
+    /// </summary>
     [System.Runtime.CompilerServices.CompilerGenerated]
     public static partial class Exports
     {
+        /// <summary>
+        /// The conventions exports from this assembly
+        /// </summary>
         public static IEnumerable<IConventionWithDependencies> GetConventions(IServiceProvider serviceProvider)
         {
             yield return new ConventionWithDependencies(ActivatorUtilities.CreateInstance<Rocket.Surgery.Conventions.Tests.ParentContrib.Contrib>(serviceProvider), HostType.Undefined);
@@ -364,9 +463,10 @@ namespace TestProject.Conventions
 ";
 
         await AssertGeneratedAsExpected<ConventionAttributesGenerator>(
-            new[] { typeof(Class1).Assembly, typeof(Class2).Assembly, typeof(Class3).Assembly },
+            await CreateDeps(),
             source,
-            expected
+            expected,
+            "Exported_Conventions.cs"
         ).ConfigureAwait(false);
     }
 }

--- a/test/Analyzers.Tests/GenerationHelpers.cs
+++ b/test/Analyzers.Tests/GenerationHelpers.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using FluentAssertions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -43,21 +44,51 @@ public static class GenerationHelpers
 
     internal static readonly ImmutableArray<PortableExecutableReference> MetadataReferences;
 
-    public static async Task AssertGeneratedAsExpected<T>(IEnumerable<Assembly> metadataReferences, string source, string expected)
+    public static async Task AssertGeneratedAsExpected<T>(
+        IEnumerable<Assembly> metadataReferences,
+        string source,
+        string expected,
+        string? expectedFileHint = null
+    )
         where T : new()
     {
-        var generatedTree = await GenerateAsync<T>(new[] { source }, metadataReferences).ConfigureAwait(false);
+        var generatedTree = await GenerateAsync<T>(new[] { source }, metadataReferences, Array.Empty<MetadataReference>()).ConfigureAwait(false);
         // normalize line endings to just LF
-        var generatedText = generatedTree.Select(z => NormalizeToLf(z.GetText().ToString()));
+        var generatedText = generatedTree
+                           .Where(z => string.IsNullOrWhiteSpace(expectedFileHint) || z.FilePath.Contains(expectedFileHint, StringComparison.OrdinalIgnoreCase))
+                           .Select(z => NormalizeToLf(z.GetText().ToString()));
         // and append preamble to the expected
         var expectedText = NormalizeToLf(expected).Trim();
         generatedText.Last().Should().Be(expectedText);
     }
 
-    public static async Task AssertGeneratedAsExpected<T>(IEnumerable<Assembly> metadataReferences, IEnumerable<string> sources, IEnumerable<string> expected)
+
+    public static async Task AssertGeneratedAsExpected<T>(
+        IEnumerable<MetadataReference> metadataReferences,
+        string source,
+        string expected,
+        string? expectedFileHint = null
+    )
         where T : new()
     {
-        var generatedTree = await GenerateAsync<T>(sources, metadataReferences).ConfigureAwait(false);
+        var generatedTree = await GenerateAsync<T>(new[] { source }, Array.Empty<Assembly>(), metadataReferences).ConfigureAwait(false);
+        // normalize line endings to just LF
+        var generatedText = generatedTree
+                           .Where(z => string.IsNullOrWhiteSpace(expectedFileHint) || z.FilePath.Contains(expectedFileHint, StringComparison.OrdinalIgnoreCase))
+                           .Select(z => NormalizeToLf(z.GetText().ToString()));
+        // and append preamble to the expected
+        var expectedText = NormalizeToLf(expected).Trim();
+        generatedText.Last().Should().Be(expectedText);
+    }
+
+    public static async Task AssertGeneratedAsExpected<T>(
+        IEnumerable<Assembly> metadataReferences,
+        IEnumerable<string> sources,
+        IEnumerable<string> expected
+    )
+        where T : new()
+    {
+        var generatedTree = await GenerateAsync<T>(sources, metadataReferences, Array.Empty<MetadataReference>()).ConfigureAwait(false);
         // normalize line endings to just LF
         var generatedText = generatedTree.Select(z => NormalizeToLf(z.GetText().ToString())).ToArray();
         // and append preamble to the expected
@@ -70,31 +101,89 @@ public static class GenerationHelpers
         }
     }
 
-    public static async Task AssertGeneratedAsExpected<T>(string source, string expected)
+    public static async Task AssertGeneratedAsExpected<T>(
+        IEnumerable<MetadataReference> metadataReferences,
+        IEnumerable<string> sources,
+        IEnumerable<string> expected
+    )
         where T : new()
     {
-        var generatedTree = await GenerateAsync<T>(new[] { source }, Array.Empty<Assembly>()).ConfigureAwait(false);
+        var generatedTree = await GenerateAsync<T>(sources, Array.Empty<Assembly>(), metadataReferences).ConfigureAwait(false);
         // normalize line endings to just LF
-        var generatedText = generatedTree.Select(z => NormalizeToLf(z.GetText().ToString()));
+        var generatedText = generatedTree.Select(z => NormalizeToLf(z.GetText().ToString())).ToArray();
+        // and append preamble to the expected
+        var expectedText = expected.Select(z => NormalizeToLf(z).Trim()).ToArray();
+
+        generatedText.Should().HaveCount(expectedText.Length);
+        foreach (var (generated, expectedTxt) in generatedText.Zip(expectedText, (generated, expected) => ( generated, expected )))
+        {
+            generated.Should().Be(expectedTxt);
+        }
+    }
+
+    public static async Task AssertGeneratedAsExpected<T>(
+        string source,
+        string expected,
+        string? expectedFileHint = null
+    )
+        where T : new()
+    {
+        var generatedTree = await GenerateAsync<T>(new[] { source }, Array.Empty<Assembly>(), Array.Empty<MetadataReference>()).ConfigureAwait(false);
+        // normalize line endings to just LF
+        var generatedText = generatedTree
+                           .Where(z => string.IsNullOrWhiteSpace(expectedFileHint) || z.FilePath.Contains(expectedFileHint, StringComparison.OrdinalIgnoreCase))
+                           .Select(z => NormalizeToLf(z.GetText().ToString()));
         // and append preamble to the expected
         var expectedText = NormalizeToLf(expected).Trim();
         generatedText.Last().Should().Be(expectedText);
     }
 
-    public static async Task<string> Generate<T>(IEnumerable<Assembly> metadataReferences, string source)
+    public static async Task<string> Generate<T>(
+        IEnumerable<Assembly> metadataReferences,
+        string source
+    )
         where T : new()
     {
-        var generatedTree = await GenerateAsync<T>(new[] { source }, metadataReferences).ConfigureAwait(false);
+        var generatedTree = await GenerateAsync<T>(new[] { source }, metadataReferences, Array.Empty<MetadataReference>()).ConfigureAwait(false);
         // normalize line endings to just LF
         var generatedText = generatedTree.Select(z => NormalizeToLf(z.GetText().ToString()));
         // and append preamble to the expected
         return generatedText.Last();
     }
 
-    public static async Task<string[]> Generate<T>(IEnumerable<Assembly> metadataReferences, IEnumerable<string> sources)
+    public static async Task<string> Generate<T>(
+        IEnumerable<MetadataReference> metadataReferences,
+        string source
+    )
         where T : new()
     {
-        var generatedTree = await GenerateAsync<T>(sources, metadataReferences).ConfigureAwait(false);
+        var generatedTree = await GenerateAsync<T>(new[] { source }, Array.Empty<Assembly>(), metadataReferences).ConfigureAwait(false);
+        // normalize line endings to just LF
+        var generatedText = generatedTree.Select(z => NormalizeToLf(z.GetText().ToString()));
+        // and append preamble to the expected
+        return generatedText.Last();
+    }
+
+    public static async Task<string[]> Generate<T>(
+        IEnumerable<Assembly> metadataReferences,
+        IEnumerable<string> sources
+    )
+        where T : new()
+    {
+        var generatedTree = await GenerateAsync<T>(sources, metadataReferences, Array.Empty<MetadataReference>()).ConfigureAwait(false);
+        // normalize line endings to just LF
+        var generatedText = generatedTree.Select(z => NormalizeToLf(z.GetText().ToString()));
+        // and append preamble to the expected
+        return generatedText.ToArray();
+    }
+
+    public static async Task<string[]> Generate<T>(
+        IEnumerable<MetadataReference> metadataReferences,
+        IEnumerable<string> sources
+    )
+        where T : new()
+    {
+        var generatedTree = await GenerateAsync<T>(sources, Array.Empty<Assembly>(), metadataReferences).ConfigureAwait(false);
         // normalize line endings to just LF
         var generatedText = generatedTree.Select(z => NormalizeToLf(z.GetText().ToString()));
         // and append preamble to the expected
@@ -104,14 +193,35 @@ public static class GenerationHelpers
     public static async Task<string> Generate<T>(string source)
         where T : new()
     {
-        var generatedTree = await GenerateAsync<T>(new[] { source }, Array.Empty<Assembly>()).ConfigureAwait(false);
+        var generatedTree = await GenerateAsync<T>(new[] { source }, Array.Empty<Assembly>(), Array.Empty<MetadataReference>()).ConfigureAwait(false);
         // normalize line endings to just LF
         var generatedText = generatedTree.Select(z => NormalizeToLf(z.GetText().ToString()));
         // and append preamble to the expected
         return generatedText.Last();
     }
 
-    public static async Task<IEnumerable<SyntaxTree>> GenerateAsync<T>(IEnumerable<string> sources, IEnumerable<Assembly> metadataReferences)
+    public static async Task<IEnumerable<SyntaxTree>> GenerateAsync<T>(
+        IEnumerable<string> sources,
+        IEnumerable<Assembly> metadataReferences,
+        IEnumerable<MetadataReference> compilationReferences
+    )
+        where T : new()
+    {
+        // Assert.Empty(diagnostics.Where(x => x.Severity >= DiagnosticSeverity.Warning));
+
+        var (outputCompilation, startingSyntaxTress) = await InnerGenerateCompilationAsync<T>(sources, metadataReferences, compilationReferences);
+
+        // the syntax tree added by the generator will be the last one in the compilation
+        return outputCompilation
+              .SyntaxTrees.TakeLast(outputCompilation.SyntaxTrees.Count() - startingSyntaxTress);
+    }
+
+    private static async Task<(Compilation compilation, int trees)> InnerGenerateCompilationAsync<T>(
+        IEnumerable<string> sources,
+        IEnumerable<Assembly> metadataReferences,
+        IEnumerable<MetadataReference> compilationReferences,
+        string? projectName = null
+    )
         where T : new()
     {
         var references = metadataReferences
@@ -122,12 +232,14 @@ public static class GenerationHelpers
                                  typeof(ConventionAttribute).Assembly,
                                  typeof(ConventionContext).Assembly,
                                  typeof(IConventionContext).Assembly,
+                                 typeof(IServiceProvider).Assembly,
                              }
                          )
                         .Distinct()
                         .Select(x => MetadataReference.CreateFromFile(x.Location))
+                        .Concat(compilationReferences)
                         .ToArray();
-        var project = CreateProject(references, sources.ToArray());
+        var project = CreateProject(references, projectName ?? TestProjectName, sources.ToArray());
 
         var compilation = (CSharpCompilation?)await project.GetCompilationAsync().ConfigureAwait(false);
         if (compilation is null)
@@ -138,7 +250,7 @@ public static class GenerationHelpers
         var startingSyntaxTress = compilation.SyntaxTrees.Length;
 
         var diagnostics = compilation.GetDiagnostics();
-        Assert.Empty(diagnostics.Where(x => x.Severity >= DiagnosticSeverity.Warning));
+        Assert.Empty(diagnostics.Where(z => z.Id != "CS8632").Where(x => x.Severity >= DiagnosticSeverity.Warning));
 
         var generator = new T();
         var driver =
@@ -150,19 +262,37 @@ public static class GenerationHelpers
         // Assert.Empty(diagnostics.Where(x => x.Severity >= DiagnosticSeverity.Warning));
 
         // the syntax tree added by the generator will be the last one in the compilation
-        return outputCompilation.SyntaxTrees.TakeLast(outputCompilation.SyntaxTrees.Count() - startingSyntaxTress);
+        return ( outputCompilation, startingSyntaxTress );
     }
 
-    public static Project CreateProject(IEnumerable<MetadataReference> metadataReferences, params string[] sources)
+    public static async Task<MetadataReference> GenerateCompilationAsync<T>(
+        IEnumerable<string> sources,
+        IEnumerable<Assembly> metadataReferences,
+        IEnumerable<MetadataReference> compilationReferences,
+        string projectName
+    )
+        where T : new()
     {
-        var projectId = ProjectId.CreateNewId(TestProjectName);
+        var compilation = ( await InnerGenerateCompilationAsync<T>(sources, metadataReferences, compilationReferences, projectName) ).compilation;
+
+        var memoryStream = new MemoryStream();
+        var result = compilation.Emit(memoryStream, options: new EmitOptions(outputNameOverride: projectName));
+        if (!result.Success) throw new Exception("Error compiling compliation");
+        memoryStream.Seek(0, SeekOrigin.Begin);
+        return MetadataReference.CreateFromStream(memoryStream, filePath: projectName);
+    }
+
+    public static Project CreateProject(IEnumerable<MetadataReference> metadataReferences, string projectName, params string[] sources)
+    {
+        var projectId = ProjectId.CreateNewId(projectName);
         var solution = new AdhocWorkspace()
                       .CurrentSolution
-                      .AddProject(projectId, TestProjectName, TestProjectName, LanguageNames.CSharp)
+                      .AddProject(projectId, projectName, projectName, LanguageNames.CSharp)
                       .WithProjectCompilationOptions(
                            projectId,
                            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
                        )
+                      .WithProjectAssemblyName(projectId, projectName)
                       .WithProjectParseOptions(
                            projectId,
                            new CSharpParseOptions(preprocessorSymbols: new[] { "SOMETHING_ACTIVE" })
@@ -190,5 +320,79 @@ public static class GenerationHelpers
     public static string NormalizeToLf(string input)
     {
         return input.Replace(CrLf, Lf);
+    }
+
+    public static async Task<IEnumerable<MetadataReference>> CreateDeps()
+    {
+        var c1 = await Class1();
+        var c2 = await Class2();
+        var c3 = await Class3(c1);
+        return new[] { c1, c2, c3 };
+    }
+
+    public static Task<MetadataReference> Class1()
+    {
+        return GenerateCompilationAsync<ConventionAttributesGenerator>(
+            new[]
+            {
+                @"using Rocket.Surgery.Conventions;
+using Sample.DependencyOne;
+
+[assembly: ExportConventions(Namespace = ""Dep1"", ClassName = ""Dep1Exports"")]
+[assembly: Convention(typeof(Class1))]
+
+namespace Sample.DependencyOne;
+
+public class Class1 : IConvention
+{
+}
+"
+            }, ImmutableArray<Assembly>.Empty, ImmutableArray<MetadataReference>.Empty,
+            "SampleDependencyOne"
+        );
+    }
+
+    public static Task<MetadataReference> Class2()
+    {
+        return GenerateCompilationAsync<ConventionAttributesGenerator>(
+            new[]
+            {
+                @"using Rocket.Surgery.Conventions;
+using Sample.DependencyTwo;
+
+[assembly: ExportConventions(Namespace = ""Dep2"", ClassName = ""Dep2Exports"")]
+[assembly: Convention(typeof(Class2))]
+
+namespace Sample.DependencyTwo;
+
+public class Class2 : IConvention
+{
+}"
+            }, ImmutableArray<Assembly>.Empty, ImmutableArray<MetadataReference>.Empty,
+            "SampleDependencyTwo"
+        );
+    }
+
+    public static Task<MetadataReference> Class3(MetadataReference class1)
+    {
+        return GenerateCompilationAsync<ConventionAttributesGenerator>(
+            new[]
+            {
+                @"using Rocket.Surgery.Conventions;
+using Sample.DependencyOne;
+using Sample.DependencyThree;
+
+[assembly: Convention(typeof(Class3))]
+
+namespace Sample.DependencyThree;
+
+public class Class3 : IConvention
+{
+    public Class1? Class1 { get; set; }
+}
+"
+            }, ImmutableArray<Assembly>.Empty, ImmutableArray.Create(class1),
+            "SampleDependencyThree"
+        );
     }
 }

--- a/test/Analyzers.Tests/ImportConventionsTests.cs
+++ b/test/Analyzers.Tests/ImportConventionsTests.cs
@@ -1,8 +1,5 @@
 using System.Reflection;
 using FluentAssertions;
-using Sample.DependencyOne;
-using Sample.DependencyThree;
-using Sample.DependencyTwo;
 using Xunit;
 using static Rocket.Surgery.Conventions.Analyzers.Tests.GenerationHelpers;
 
@@ -23,18 +20,26 @@ using System;
 using System.Collections.Generic;
 using Rocket.Surgery.Conventions;
 
+[assembly: System.Reflection.AssemblyMetadata(""Rocket.Surgery.ConventionConfigurationData.Imports.Namespace"", ""TestProject.Conventions"")]
+[assembly: System.Reflection.AssemblyMetadata(""Rocket.Surgery.ConventionConfigurationData.Imports.ClassName"", ""Imports"")]
 namespace TestProject.Conventions
 {
+    /// <summary>
+    /// The class defined for importing conventions into this assembly
+    /// </summary>
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal static partial class Imports
     {
+        /// <summary>
+        /// The conventions imported into this assembly
+        /// </summary>
         public static IEnumerable<IConventionWithDependencies> GetConventions(IServiceProvider serviceProvider)
         {
-            foreach (var convention in Sample.DependencyOne.Conventions.Exports.GetConventions(serviceProvider))
+            foreach (var convention in Dep1.Dep1Exports.GetConventions(serviceProvider))
                 yield return convention;
-            foreach (var convention in Sample.DependencyTwo.Conventions.Exports.GetConventions(serviceProvider))
+            foreach (var convention in Dep2.Dep2Exports.GetConventions(serviceProvider))
                 yield return convention;
-            foreach (var convention in Sample.DependencyThree.Conventions.Exports.GetConventions(serviceProvider))
+            foreach (var convention in SampleDependencyThree.Conventions.Exports.GetConventions(serviceProvider))
                 yield return convention;
         }
     }
@@ -42,7 +47,96 @@ namespace TestProject.Conventions
 ";
 
         await AssertGeneratedAsExpected<ConventionAttributesGenerator>(
-            new[] { typeof(Class1).Assembly, typeof(Class2).Assembly, typeof(Class3).Assembly },
+            await CreateDeps(),
+            source,
+            expected
+        ).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task Should_Generate_Static_Assembly_Level_Method_Always()
+    {
+        var source = @"
+";
+        var expected = @"
+using System;
+using System.Collections.Generic;
+using Rocket.Surgery.Conventions;
+
+[assembly: System.Reflection.AssemblyMetadata(""Rocket.Surgery.ConventionConfigurationData.Imports.Namespace"", ""TestProject.Conventions"")]
+[assembly: System.Reflection.AssemblyMetadata(""Rocket.Surgery.ConventionConfigurationData.Imports.ClassName"", ""Imports"")]
+namespace TestProject.Conventions
+{
+    /// <summary>
+    /// The class defined for importing conventions into this assembly
+    /// </summary>
+    [System.Runtime.CompilerServices.CompilerGenerated]
+    internal static partial class Imports
+    {
+        /// <summary>
+        /// The conventions imported into this assembly
+        /// </summary>
+        public static IEnumerable<IConventionWithDependencies> GetConventions(IServiceProvider serviceProvider)
+        {
+            foreach (var convention in Dep1.Dep1Exports.GetConventions(serviceProvider))
+                yield return convention;
+            foreach (var convention in Dep2.Dep2Exports.GetConventions(serviceProvider))
+                yield return convention;
+            foreach (var convention in SampleDependencyThree.Conventions.Exports.GetConventions(serviceProvider))
+                yield return convention;
+        }
+    }
+}
+";
+
+        await AssertGeneratedAsExpected<ConventionAttributesGenerator>(
+            await CreateDeps(),
+            source,
+            expected
+        ).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task Should_Generate_Static_Assembly_Level_Method_Custom_Namespace()
+    {
+        var source = @"
+using Rocket.Surgery.Conventions;
+
+[assembly: ImportConventions(Namespace = ""Test.My.Namespace"", ClassName = ""MyImports"")]
+";
+        var expected = @"
+using System;
+using System.Collections.Generic;
+using Rocket.Surgery.Conventions;
+
+[assembly: System.Reflection.AssemblyMetadata(""Rocket.Surgery.ConventionConfigurationData.Imports.Namespace"", ""Test.My.Namespace"")]
+[assembly: System.Reflection.AssemblyMetadata(""Rocket.Surgery.ConventionConfigurationData.Imports.ClassName"", ""MyImports"")]
+namespace Test.My.Namespace
+{
+    /// <summary>
+    /// The class defined for importing conventions into this assembly
+    /// </summary>
+    [System.Runtime.CompilerServices.CompilerGenerated]
+    internal static partial class MyImports
+    {
+        /// <summary>
+        /// The conventions imported into this assembly
+        /// </summary>
+        public static IEnumerable<IConventionWithDependencies> GetConventions(IServiceProvider serviceProvider)
+        {
+            foreach (var convention in Dep1.Dep1Exports.GetConventions(serviceProvider))
+                yield return convention;
+            foreach (var convention in Dep2.Dep2Exports.GetConventions(serviceProvider))
+                yield return convention;
+            foreach (var convention in SampleDependencyThree.Conventions.Exports.GetConventions(serviceProvider))
+                yield return convention;
+        }
+    }
+}
+";
+
+        await AssertGeneratedAsExpected<ConventionAttributesGenerator>(
+            await CreateDeps(),
             source,
             expected
         ).ConfigureAwait(false);
@@ -61,18 +155,26 @@ using System;
 using System.Collections.Generic;
 using Rocket.Surgery.Conventions;
 
+[assembly: System.Reflection.AssemblyMetadata(""Rocket.Surgery.ConventionConfigurationData.Imports.Namespace"", ""TestProject.Conventions"")]
+[assembly: System.Reflection.AssemblyMetadata(""Rocket.Surgery.ConventionConfigurationData.Imports.ClassName"", ""Imports"")]
 namespace TestProject.Conventions
 {
+    /// <summary>
+    /// The class defined for importing conventions into this assembly
+    /// </summary>
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal static partial class Imports
     {
+        /// <summary>
+        /// The conventions imported into this assembly
+        /// </summary>
         public static IEnumerable<IConventionWithDependencies> GetConventions(IServiceProvider serviceProvider)
         {
-            foreach (var convention in Sample.DependencyOne.Conventions.Exports.GetConventions(serviceProvider))
+            foreach (var convention in Dep1.Dep1Exports.GetConventions(serviceProvider))
                 yield return convention;
-            foreach (var convention in Sample.DependencyTwo.Conventions.Exports.GetConventions(serviceProvider))
+            foreach (var convention in Dep2.Dep2Exports.GetConventions(serviceProvider))
                 yield return convention;
-            foreach (var convention in Sample.DependencyThree.Conventions.Exports.GetConventions(serviceProvider))
+            foreach (var convention in SampleDependencyThree.Conventions.Exports.GetConventions(serviceProvider))
                 yield return convention;
         }
     }
@@ -80,7 +182,7 @@ namespace TestProject.Conventions
 ";
 
         await AssertGeneratedAsExpected<ConventionAttributesGenerator>(
-            new[] { typeof(Class1).Assembly, typeof(Class2).Assembly, typeof(Class3).Assembly },
+            await CreateDeps(),
             source,
             expected
         ).ConfigureAwait(false);
@@ -100,32 +202,56 @@ namespace TestProject
     }
 }
 ";
+        var expectedImports = @"using System;
+using System.Collections.Generic;
+using Rocket.Surgery.Conventions;
+
+[assembly: System.Reflection.AssemblyMetadata(""Rocket.Surgery.ConventionConfigurationData.Imports.Namespace"", ""TestProject.Conventions"")]
+[assembly: System.Reflection.AssemblyMetadata(""Rocket.Surgery.ConventionConfigurationData.Imports.ClassName"", ""Imports"")]
+namespace TestProject.Conventions
+{
+    /// <summary>
+    /// The class defined for importing conventions into this assembly
+    /// </summary>
+    [System.Runtime.CompilerServices.CompilerGenerated]
+    internal static partial class Imports
+    {
+        /// <summary>
+        /// The conventions imported into this assembly
+        /// </summary>
+        public static IEnumerable<IConventionWithDependencies> GetConventions(IServiceProvider serviceProvider)
+        {
+            foreach (var convention in Dep1.Dep1Exports.GetConventions(serviceProvider))
+                yield return convention;
+            foreach (var convention in Dep2.Dep2Exports.GetConventions(serviceProvider))
+                yield return convention;
+            foreach (var convention in SampleDependencyThree.Conventions.Exports.GetConventions(serviceProvider))
+                yield return convention;
+        }
+    }
+}";
         var expected = @"
 using System;
 using System.Collections.Generic;
 using Rocket.Surgery.Conventions;
+using TestProject.Conventions;
 
 namespace TestProject
 {
     public partial class Program
     {
-        public static IEnumerable<IConventionWithDependencies> GetConventions(IServiceProvider serviceProvider)
-        {
-            foreach (var convention in Sample.DependencyOne.Conventions.Exports.GetConventions(serviceProvider))
-                yield return convention;
-            foreach (var convention in Sample.DependencyTwo.Conventions.Exports.GetConventions(serviceProvider))
-                yield return convention;
-            foreach (var convention in Sample.DependencyThree.Conventions.Exports.GetConventions(serviceProvider))
-                yield return convention;
-        }
+        /// <summary>
+        /// The conventions imported into this assembly
+        /// </summary>
+        public static IEnumerable<IConventionWithDependencies> GetConventions(IServiceProvider serviceProvider) => Imports.GetConventions(serviceProvider);
     }
 }
 ";
 
         await AssertGeneratedAsExpected<ConventionAttributesGenerator>(
-            new[] { typeof(Class1).Assembly, typeof(Class2).Assembly, typeof(Class3).Assembly },
-            source,
-            expected
+            await CreateDeps(),
+            new[] { source },
+            new[] { expectedImports, expected }
         ).ConfigureAwait(false);
     }
 
@@ -144,32 +270,56 @@ namespace TestProject
     }
 }
 ";
+        var expectedImports = @"using System;
+using System.Collections.Generic;
+using Rocket.Surgery.Conventions;
+
+[assembly: System.Reflection.AssemblyMetadata(""Rocket.Surgery.ConventionConfigurationData.Imports.Namespace"", ""TestProject.Conventions"")]
+[assembly: System.Reflection.AssemblyMetadata(""Rocket.Surgery.ConventionConfigurationData.Imports.ClassName"", ""Imports"")]
+namespace TestProject.Conventions
+{
+    /// <summary>
+    /// The class defined for importing conventions into this assembly
+    /// </summary>
+    [System.Runtime.CompilerServices.CompilerGenerated]
+    internal static partial class Imports
+    {
+        /// <summary>
+        /// The conventions imported into this assembly
+        /// </summary>
+        public static IEnumerable<IConventionWithDependencies> GetConventions(IServiceProvider serviceProvider)
+        {
+            foreach (var convention in Dep1.Dep1Exports.GetConventions(serviceProvider))
+                yield return convention;
+            foreach (var convention in Dep2.Dep2Exports.GetConventions(serviceProvider))
+                yield return convention;
+            foreach (var convention in SampleDependencyThree.Conventions.Exports.GetConventions(serviceProvider))
+                yield return convention;
+        }
+    }
+}";
         var expected = @"
 using System;
 using System.Collections.Generic;
 using Rocket.Surgery.Conventions;
+using TestProject.Conventions;
 
 namespace TestProject
 {
     public partial class Program
     {
-        public static IEnumerable<IConventionWithDependencies> GetConventions(IServiceProvider serviceProvider)
-        {
-            foreach (var convention in Sample.DependencyOne.Conventions.Exports.GetConventions(serviceProvider))
-                yield return convention;
-            foreach (var convention in Sample.DependencyTwo.Conventions.Exports.GetConventions(serviceProvider))
-                yield return convention;
-            foreach (var convention in Sample.DependencyThree.Conventions.Exports.GetConventions(serviceProvider))
-                yield return convention;
-        }
+        /// <summary>
+        /// The conventions imported into this assembly
+        /// </summary>
+        public static IEnumerable<IConventionWithDependencies> GetConventions(IServiceProvider serviceProvider) => Imports.GetConventions(serviceProvider);
     }
 }
 ";
 
         await AssertGeneratedAsExpected<ConventionAttributesGenerator>(
-            new[] { typeof(Class1).Assembly, typeof(Class2).Assembly, typeof(Class3).Assembly },
-            source,
-            expected
+            await CreateDeps(),
+            new[] { source },
+            new[] { expectedImports, expected }
         ).ConfigureAwait(false);
     }
 
@@ -181,25 +331,35 @@ using Rocket.Surgery.Conventions;
 
 [assembly: ImportConventions]
 ";
-        var expected = @"
-using System;
+        var expectedImports = @"using System;
 using System.Collections.Generic;
 using Rocket.Surgery.Conventions;
 
+[assembly: System.Reflection.AssemblyMetadata(""Rocket.Surgery.ConventionConfigurationData.Imports.Namespace"", ""TestProject.Conventions"")]
+[assembly: System.Reflection.AssemblyMetadata(""Rocket.Surgery.ConventionConfigurationData.Imports.ClassName"", ""Imports"")]
 namespace TestProject.Conventions
 {
+    /// <summary>
+    /// The class defined for importing conventions into this assembly
+    /// </summary>
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal static partial class Imports
     {
+        /// <summary>
+        /// The conventions imported into this assembly
+        /// </summary>
         public static IEnumerable<IConventionWithDependencies> GetConventions(IServiceProvider serviceProvider)
         {
             yield break;
         }
     }
-}
-";
-
-        await AssertGeneratedAsExpected<ConventionAttributesGenerator>(source, expected).ConfigureAwait(false);
+}";
+        await AssertGeneratedAsExpected<ConventionAttributesGenerator>(
+            Enumerable.Empty<Assembly>(), new[] { source }, new[]
+            {
+                expectedImports
+            }
+        ).ConfigureAwait(false);
     }
 
     [Fact]
@@ -227,20 +387,44 @@ namespace TestProject
     }
 }
 ";
-        var expected1 = @"
-using System;
+        var expectedImports = @"using System;
 using System.Collections.Generic;
 using Rocket.Surgery.Conventions;
 
-namespace TestProject
+[assembly: System.Reflection.AssemblyMetadata(""Rocket.Surgery.ConventionConfigurationData.Imports.Namespace"", ""TestProject.Conventions"")]
+[assembly: System.Reflection.AssemblyMetadata(""Rocket.Surgery.ConventionConfigurationData.Imports.ClassName"", ""Imports"")]
+namespace TestProject.Conventions
 {
-    public partial class Program
+    /// <summary>
+    /// The class defined for importing conventions into this assembly
+    /// </summary>
+    [System.Runtime.CompilerServices.CompilerGenerated]
+    internal static partial class Imports
     {
+        /// <summary>
+        /// The conventions imported into this assembly
+        /// </summary>
         public static IEnumerable<IConventionWithDependencies> GetConventions(IServiceProvider serviceProvider)
         {
             foreach (var convention in TestProject.Conventions.Exports.GetConventions(serviceProvider))
                 yield return convention;
         }
+    }
+}";
+        var expected1 = @"
+using System;
+using System.Collections.Generic;
+using Rocket.Surgery.Conventions;
+using TestProject.Conventions;
+
+namespace TestProject
+{
+    public partial class Program
+    {
+        /// <summary>
+        /// The conventions imported into this assembly
+        /// </summary>
+        public static IEnumerable<IConventionWithDependencies> GetConventions(IServiceProvider serviceProvider) => Imports.GetConventions(serviceProvider);
     }
 }
 ";
@@ -250,19 +434,26 @@ using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
 using Rocket.Surgery.Conventions;
 
+[assembly: System.Reflection.AssemblyMetadata(""Rocket.Surgery.ConventionConfigurationData.Exports.Namespace"", ""TestProject.Conventions"")]
+[assembly: System.Reflection.AssemblyMetadata(""Rocket.Surgery.ConventionConfigurationData.Exports.ClassName"", ""Exports"")]
 [assembly: ExportedConventions(typeof(Rocket.Surgery.Conventions.Tests.Contrib))]
 namespace TestProject.Conventions
 {
+    /// <summary>
+    /// The class defined for exporting conventions from this assembly
+    /// </summary>
     [System.Runtime.CompilerServices.CompilerGenerated]
     public static partial class Exports
     {
+        /// <summary>
+        /// The conventions exports from this assembly
+        /// </summary>
         public static IEnumerable<IConventionWithDependencies> GetConventions(IServiceProvider serviceProvider)
         {
             yield return new ConventionWithDependencies(ActivatorUtilities.CreateInstance<Rocket.Surgery.Conventions.Tests.Contrib>(serviceProvider), HostType.Undefined);
         }
     }
-}
-";
+}";
 
         var responses = await Generate<ConventionAttributesGenerator>(
             Array.Empty<Assembly>(),
@@ -281,6 +472,10 @@ namespace TestProject.Conventions
             else if (response.Contains("class Program", StringComparison.OrdinalIgnoreCase))
             {
                 response.Should().Be(NormalizeToLf(expected1).Trim());
+            }
+            else if (response.Contains("class Imports", StringComparison.OrdinalIgnoreCase))
+            {
+                response.Should().Be(NormalizeToLf(expectedImports).Trim());
             }
             else
             {

--- a/test/Analyzers.Tests/Rocket.Surgery.Conventions.Analyzers.Tests.csproj
+++ b/test/Analyzers.Tests/Rocket.Surgery.Conventions.Analyzers.Tests.csproj
@@ -5,9 +5,6 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" PrivateAssets="all" />
-        <ProjectReference Include="..\..\sample\Sample.DependencyOne\Sample.DependencyOne.csproj" />
-        <ProjectReference Include="..\..\sample\Sample.DependencyThree\Sample.DependencyThree.csproj" />
-        <ProjectReference Include="..\..\sample\Sample.DependencyTwo\Sample.DependencyTwo.csproj" />
         <ProjectReference Include="..\..\src\Conventions.Analyzers\Rocket.Surgery.Conventions.Analyzers.csproj" OutputItemType="Analyzer" />
         <ProjectReference Include="..\..\src\Conventions.Diagnostics\Rocket.Surgery.Conventions.Diagnostics.csproj" />
         <ProjectReference Include="..\..\src\Conventions\Rocket.Surgery.Conventions.csproj" />


### PR DESCRIPTION
By default the imports class will always be generated in the default namespace `X.Conventions`